### PR TITLE
[FEAT] Member 엔티티에 관리자 추가

### DIFF
--- a/src/main/java/com/insidemovie/backend/BackendApplication.java
+++ b/src/main/java/com/insidemovie/backend/BackendApplication.java
@@ -1,8 +1,14 @@
 package com.insidemovie.backend;
 
+import com.insidemovie.backend.api.constant.Authority;
+import com.insidemovie.backend.api.member.entity.Member;
+import com.insidemovie.backend.api.member.repository.MemberRepository;
+import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 @SpringBootApplication
 @EnableJpaAuditing
@@ -11,5 +17,17 @@ public class BackendApplication {
 	public static void main(String[] args) {
 		SpringApplication.run(BackendApplication.class, args);
 	}
-
+	@Bean
+	CommandLineRunner initAdmin(MemberRepository repo, PasswordEncoder encoder) {
+		return args -> {
+			if (!repo.existsByEmail("admin@test.com")) {
+				Member admin = Member.builder()
+						.email("admin@test.com")
+						.password(encoder.encode("adminA!123"))
+						.authority(Authority.ROLE_ADMIN)
+						.build();
+				repo.save(admin);
+			}
+		};
+	}
 }

--- a/src/main/java/com/insidemovie/backend/api/admin/controller/AdminController.java
+++ b/src/main/java/com/insidemovie/backend/api/admin/controller/AdminController.java
@@ -1,0 +1,29 @@
+package com.insidemovie.backend.api.admin.controller;
+
+import com.insidemovie.backend.api.member.repository.MemberRepository;
+import com.insidemovie.backend.common.exception.BadRequestException;
+import com.insidemovie.backend.common.response.ApiResponse;
+import com.insidemovie.backend.common.response.SuccessStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin")
+public class AdminController {
+
+    private final MemberRepository memberRepository;
+    @GetMapping("/totalSub")
+    public ResponseEntity<ApiResponse<Long>> getTotalSub() {
+        Long total = null;
+        try {
+            total = memberRepository.count();
+            return ApiResponse.success(SuccessStatus.CREATE_SAMPLE_SUCCESS, total);
+        } catch (Exception e) {
+            throw new BadRequestException("전체 회원 조회 오류 : " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/insidemovie/backend/api/jwt/JwtProvider.java
+++ b/src/main/java/com/insidemovie/backend/api/jwt/JwtProvider.java
@@ -46,7 +46,8 @@ public class JwtProvider {
         String accessToken =
                 Jwts.builder()
                         .setSubject(authentication.getName()) // 사용자명 설정, 이메일이 들어 있음
-                        .claim(AUTHORITIES_KEY, "ROLE_USER")  // 권한 정보 저장, 일단 ROLE_USER
+                        //.claim(AUTHORITIES_KEY, "ROLE_USER")  // 권한 정보 저장, 일단 ROLE_USER
+                        .claim(AUTHORITIES_KEY, authorities)
                         .setExpiration(accessTokenExpiresIn)  // 만료 시간 설정
                         .signWith(key, SignatureAlgorithm.HS512) // 서명 방식 설정
                         .compact();

--- a/src/main/java/com/insidemovie/backend/api/member/entity/Member.java
+++ b/src/main/java/com/insidemovie/backend/api/member/entity/Member.java
@@ -31,7 +31,9 @@ public class Member extends BaseTimeEntity {
 
     // jwt
     @Enumerated(EnumType.STRING)
+    @Column(nullable=false)
     private Authority authority;
+
 
     @Builder
     public Member(String email, String password, String nickname, Authority authority) {

--- a/src/main/java/com/insidemovie/backend/api/member/service/MemberService.java
+++ b/src/main/java/com/insidemovie/backend/api/member/service/MemberService.java
@@ -10,9 +10,13 @@ import com.insidemovie.backend.common.exception.BadRequestException;
 import com.insidemovie.backend.common.exception.NotFoundException;
 import com.insidemovie.backend.common.response.ErrorStatus;
 import lombok.RequiredArgsConstructor;
+
+import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,6 +32,7 @@ public class MemberService {
     private final PasswordEncoder passwordEncoder;
     private final JwtProvider jwtProvider;
     private final OAuthService oAuthService;
+
 
     // 이메일 회원가입 메서드
     @Transactional
@@ -111,7 +116,20 @@ public class MemberService {
             throw new BadRequestException(ErrorStatus.PASSWORD_MISMATCH_EXCEPTION.getMessage());
         }
         // 인증 객체 생성 (Spring Security용)
-        Authentication authentication = memberLoginRequestDto.toAuthentication();
+        //Authentication authentication = memberLoginRequestDto.toAuthentication();
+        // 2) 권한 컬렉션 생성
+        List<GrantedAuthority> authorities = List.of(
+                new SimpleGrantedAuthority(member.getAuthority().name())
+        );
+        // 3) 인증 후 토큰 생성
+        Authentication authentication =
+                new UsernamePasswordAuthenticationToken(
+                        member,                   // principal: UserDetails
+                        null,                   // credentials: 이미 검사했으니 null
+                        authorities  // 권한 목록
+                );
+
+
 
         // JWT 토큰 발급
         String accessToken = jwtProvider.generateAccessToken(authentication);

--- a/src/main/java/com/insidemovie/backend/common/config/security/SecurityConfig.java
+++ b/src/main/java/com/insidemovie/backend/common/config/security/SecurityConfig.java
@@ -7,6 +7,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
@@ -59,6 +61,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/h2-console/**", "/swagger-ui/**", "/v3/api-docs/**", "/swagger-resources/**", "/swagger-ui.html", "/webjars/**", "/api-doc").permitAll() // H2, Swagger 인증 허용
                         .requestMatchers("/api/v1/member/signup", "/api/v1/member/reissue", "/api/v1/member/login", "/api/v1/member/kakao-accesstoken", "/api/v1/member/kakao-login", "/api/v1/member/token-reissue").permitAll() // 회원가입, 로그인 인증 허용
+                        .requestMatchers("/api/admin/**").hasRole("ADMIN")
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(new JwtFilter(jwtProvider), UsernamePasswordAuthenticationFilter.class)
@@ -68,4 +71,6 @@ public class SecurityConfig {
 
         return http.build();
     }
+
+
 }


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #22 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- member 엔티티에서 authority 컬럼으로 권한 부여
- 어플리케이션 시작 시 초기 관리자 자동 생성하여 최초 관리자 등록 
- 관리자 계정 test하기 위해 admin controller 만들어서 회원 수 출력 test

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 관리자 페이지 안에 “회원 관리” 화면을 만들어 두고, 목록에서 ‘승격(Promote)’ 버튼을 눌러 해당 계정의 role 을 바꾸도록 구현할 수도 있음

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
