### PR TITLE
Feat/#26

### DIFF
--- a/src/main/java/com/insidemovie/backend/api/review/controller/ReviewController.java
+++ b/src/main/java/com/insidemovie/backend/api/review/controller/ReviewController.java
@@ -46,7 +46,7 @@ public class ReviewController {
     public ResponseEntity<ApiResponse<Page<ReviewResponseDTO>>> getReviewsByMovie(
             @PathVariable Long movieId,
             @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(defaultValue = "20") int size,
             @AuthenticationPrincipal UserDetails userDetails
     ) {
         String userEmail = (userDetails != null) ? userDetails.getUsername() : null;

--- a/src/main/java/com/insidemovie/backend/api/review/dto/EmotionDTO.java
+++ b/src/main/java/com/insidemovie/backend/api/review/dto/EmotionDTO.java
@@ -1,0 +1,16 @@
+package com.insidemovie.backend.api.review.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+
+public class EmotionDTO {
+    private Double anger;
+    private Double fear;
+    private Double joy;
+    private Double neutral;
+    private Double sadness;
+    private String repEmotion;
+}

--- a/src/main/java/com/insidemovie/backend/api/review/dto/PredictRequestDTO.java
+++ b/src/main/java/com/insidemovie/backend/api/review/dto/PredictRequestDTO.java
@@ -1,0 +1,11 @@
+package com.insidemovie.backend.api.review.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+
+public class PredictRequestDTO {
+    private String text;
+}

--- a/src/main/java/com/insidemovie/backend/api/review/dto/PredictResponseDTO.java
+++ b/src/main/java/com/insidemovie/backend/api/review/dto/PredictResponseDTO.java
@@ -1,0 +1,15 @@
+package com.insidemovie.backend.api.review.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import java.time.Instant;
+import java.util.Map;
+
+@Getter
+@NoArgsConstructor
+
+public class PredictResponseDTO {
+    private String text;
+    private Map<String, Double> probabilities;
+    private Instant instant;
+}

--- a/src/main/java/com/insidemovie/backend/api/review/dto/ReviewResponseDTO.java
+++ b/src/main/java/com/insidemovie/backend/api/review/dto/ReviewResponseDTO.java
@@ -25,4 +25,6 @@ public class ReviewResponseDTO {
 
     private Long memberId;  // 작성자 ID
     private Long movieId;
+
+    private EmotionDTO emotion; // 감정 상태 DTO
 }

--- a/src/main/java/com/insidemovie/backend/api/review/entity/Emotion.java
+++ b/src/main/java/com/insidemovie/backend/api/review/entity/Emotion.java
@@ -26,6 +26,6 @@ public class Emotion {
     private double neutral;
 
     @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "review_id", nullable = false)
+    @JoinColumn(name = "review_id", nullable = false, unique = true)
     private Review review;
 }

--- a/src/main/java/com/insidemovie/backend/api/review/repository/EmotionRespository.java
+++ b/src/main/java/com/insidemovie/backend/api/review/repository/EmotionRespository.java
@@ -2,6 +2,8 @@ package com.insidemovie.backend.api.review.repository;
 
 import com.insidemovie.backend.api.review.entity.Emotion;
 import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
 
 public interface EmotionRespository extends JpaRepository<Emotion, Long> {
+    Optional<Emotion> findByReviewId(Long reviewId);
 }

--- a/src/main/java/com/insidemovie/backend/api/review/repository/EmotionRespository.java
+++ b/src/main/java/com/insidemovie/backend/api/review/repository/EmotionRespository.java
@@ -1,0 +1,7 @@
+package com.insidemovie.backend.api.review.repository;
+
+import com.insidemovie.backend.api.review.entity.Emotion;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EmotionRespository extends JpaRepository<Emotion, Long> {
+}

--- a/src/main/java/com/insidemovie/backend/api/review/service/ReviewService.java
+++ b/src/main/java/com/insidemovie/backend/api/review/service/ReviewService.java
@@ -4,13 +4,14 @@ import com.insidemovie.backend.api.member.entity.Member;
 import com.insidemovie.backend.api.member.repository.MemberRepository;
 import com.insidemovie.backend.api.movie.entity.Movie;
 import com.insidemovie.backend.api.movie.repository.MovieRepository;
-import com.insidemovie.backend.api.review.dto.ReviewCreateDTO;
-import com.insidemovie.backend.api.review.dto.ReviewResponseDTO;
-import com.insidemovie.backend.api.review.dto.ReviewUpdateDTO;
+import com.insidemovie.backend.api.review.dto.*;
+import com.insidemovie.backend.api.review.entity.Emotion;
 import com.insidemovie.backend.api.review.entity.Review;
+import com.insidemovie.backend.api.review.repository.EmotionRespository;
 import com.insidemovie.backend.api.review.repository.ReviewLikeRepository;
 import com.insidemovie.backend.api.review.repository.ReviewRepository;
 import com.insidemovie.backend.common.exception.BadRequestException;
+import com.insidemovie.backend.common.exception.ExternalServiceException;
 import com.insidemovie.backend.common.exception.NotFoundException;
 import com.insidemovie.backend.common.exception.UnAuthorizedException;
 import com.insidemovie.backend.common.response.ErrorStatus;
@@ -20,7 +21,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
 
+import java.util.Map;
 import java.util.Optional;
 
 @Service
@@ -32,6 +36,8 @@ public class ReviewService {
     private final ReviewRepository reviewRepository;
     private final MemberRepository memberRepository;
     private final MovieRepository movieRepository;
+    private final RestTemplate fastApiRestTemplate;
+    private final EmotionRespository emotionRespository;
 
     // 리뷰 작성 메서드
     @Transactional
@@ -44,14 +50,13 @@ public class ReviewService {
         // 영화 조회
         Movie movie = movieRepository.findById(reviewCreateDTO.getMovieId())
             .orElseThrow(() -> new NotFoundException(ErrorStatus.NOT_FOUND_MOVIE_EXCEPTION.getMessage()));
-//        Movie movie = Movie.builder().id(1L).build();
 
-
-        // 기존에 작성한리뷰가 있다면 예외 처리 (중복 방지)
+        // 기존에 작성한 리뷰가 있다면 예외 처리 (중복 방지)
         if (reviewRepository.findByMemberAndMovie(member, movie).isPresent()) {
             throw new BadRequestException(ErrorStatus.DUPLICATE_REVIEW_EXCEPTION.getMessage());
         }
 
+        // 리뷰 저장
         Review review = Review.builder()
                 .content(reviewCreateDTO.getContent())
                 .rating(reviewCreateDTO.getRating())
@@ -62,8 +67,36 @@ public class ReviewService {
                 .member(member)
                 .movie(movie)
                 .build();
-
         Review savedReview = reviewRepository.save(review);
+
+        try {
+            // FastAPI overall_avg 엔드포인트 호출
+            PredictRequestDTO request = new PredictRequestDTO(savedReview.getContent());
+            PredictResponseDTO response = fastApiRestTemplate.postForObject(
+                    "/predict/overall_avg",
+                    request,
+                    PredictResponseDTO.class
+            );
+
+            if (response == null || response.getProbabilities() == null) {
+            throw new ExternalServiceException(ErrorStatus.EXTERNAL_SERVICE_ERROR.getMessage());
+            }
+
+            Map<String, Double> probabilities = response.getProbabilities();
+
+            Emotion emotion = Emotion.builder()
+                    .anger(probabilities.get("anger"))
+                    .fear(probabilities.get("fear"))
+                    .joy(probabilities.get("joy"))
+                    .neutral(probabilities.get("neutral"))
+                    .sadness(probabilities.get("sadness"))
+                    .review(savedReview)
+                    .build();
+            emotionRespository.save(emotion);
+
+        } catch (RestClientException e) {
+            throw new ExternalServiceException(ErrorStatus.EXTERNAL_SERVICE_ERROR.getMessage());
+        }
         return savedReview.getId();
     }
 
@@ -167,7 +200,5 @@ public class ReviewService {
 
         // 리뷰 삭제
         reviewRepository.delete(review);
-
     }
-
 }

--- a/src/main/java/com/insidemovie/backend/api/review/service/ReviewService.java
+++ b/src/main/java/com/insidemovie/backend/api/review/service/ReviewService.java
@@ -136,6 +136,34 @@ public class ReviewService {
             boolean myLike = (userId != null &&
                     reviewLikeRepository.existsByReview_IdAndMember_Id(review.getId(), userId));
 
+            Optional<Emotion> optEmotion = emotionRespository.findByReviewId(review.getId());
+            EmotionDTO emotionDTO = null;
+            if (optEmotion.isPresent()) {
+                Emotion e = optEmotion.get();
+
+                Map<String, Double> probs = Map.of(
+                        "anger", e.getAnger(),
+                        "fear", e.getFear(),
+                        "joy", e.getJoy(),
+                        "neutral", e.getNeutral(),
+                        "sadness", e.getSadness()
+                );
+
+                String rep = probs.entrySet().stream()
+                        .max(Map.Entry.comparingByValue())
+                        .map(Map.Entry::getKey)
+                        .orElse("neutral"); // 최대값이 없는 경우 neutral로 설정
+
+                emotionDTO = EmotionDTO.builder()
+                        .anger(probs.get("anger"))
+                        .fear(probs.get("fear"))
+                        .joy(probs.get("joy"))
+                        .neutral(probs.get("neutral"))
+                        .sadness(probs.get("sadness"))
+                        .repEmotion(rep)
+                        .build();
+            }
+
             return ReviewResponseDTO.builder()
                     .reviewId(review.getId())
                     .content(review.getContent())
@@ -148,6 +176,7 @@ public class ReviewService {
                     .myReview(myReview)
                     .modify(review.isModify())
                     .myLike(myLike)
+                    .emotion(emotionDTO)
                     .build();
         });
     }

--- a/src/main/java/com/insidemovie/backend/common/config/WebClientConfig.java
+++ b/src/main/java/com/insidemovie/backend/common/config/WebClientConfig.java
@@ -1,0 +1,14 @@
+package com.insidemovie.backend.common.config;
+
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class WebClientConfig {
+    @Bean
+    public RestTemplate fastApiRestTemplate(RestTemplateBuilder builder) {
+        return builder.rootUri("http://localhost:8000").build();
+    }
+}

--- a/src/main/java/com/insidemovie/backend/common/config/security/SecurityConfig.java
+++ b/src/main/java/com/insidemovie/backend/common/config/security/SecurityConfig.java
@@ -6,6 +6,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
@@ -45,7 +46,8 @@ public class SecurityConfig {
                     public CorsConfiguration getCorsConfiguration(HttpServletRequest request) {
                         CorsConfiguration config = new CorsConfiguration();
                         config.setAllowedOrigins(Arrays.asList(
-                                "http://localhost:5173"
+                                "http://localhost:5173",
+                                "http://localhost:8000"
                         ));
                         config.setAllowedMethods(Collections.singletonList("*"));
                         config.setAllowCredentials(true);
@@ -62,6 +64,7 @@ public class SecurityConfig {
                         .requestMatchers("/h2-console/**", "/swagger-ui/**", "/v3/api-docs/**", "/swagger-resources/**", "/swagger-ui.html", "/webjars/**", "/api-doc").permitAll() // H2, Swagger 인증 허용
                         .requestMatchers("/api/v1/member/signup", "/api/v1/member/reissue", "/api/v1/member/login", "/api/v1/member/kakao-accesstoken", "/api/v1/member/kakao-login", "/api/v1/member/token-reissue").permitAll() // 회원가입, 로그인 인증 허용
                         .requestMatchers("/api/admin/**").hasRole("ADMIN")
+                        .requestMatchers(HttpMethod.GET, "/api/v1/review/**").permitAll() // 영화에 대한 리뷰 목록 요청 허용
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(new JwtFilter(jwtProvider), UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/com/insidemovie/backend/common/exception/ExternalServiceException.java
+++ b/src/main/java/com/insidemovie/backend/common/exception/ExternalServiceException.java
@@ -1,0 +1,10 @@
+package com.insidemovie.backend.common.exception;
+
+import com.insidemovie.backend.common.response.ErrorStatus;
+import org.springframework.http.HttpStatus;
+
+public class ExternalServiceException extends BaseException {
+    public ExternalServiceException(String message) {
+        super(HttpStatus.SERVICE_UNAVAILABLE, message);
+    }
+}

--- a/src/main/java/com/insidemovie/backend/common/response/ErrorStatus.java
+++ b/src/main/java/com/insidemovie/backend/common/response/ErrorStatus.java
@@ -31,6 +31,8 @@ public enum ErrorStatus {
     /** 500 SERVER_ERROR */
     FAIL_UPLOAD_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR,"파일 업로드 실패하였습니다."),
 
+    /** 503 ERROR */
+    EXTERNAL_SERVICE_ERROR(HttpStatus.SERVICE_UNAVAILABLE, "외부 감정 분석 서비스 호출에 실패하였습니다.")
     ;
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## 📣 Related Issue
- close #26 

## 📝 Summary
- 영화 리뷰 작성 시, FastApi의 KoBERT 모델 호출하여 반환값 Emotion Table에 저장
- 영화에 대한 리뷰 목록 조회 시, JWT 토큰 없이 조회 가능하도록 권한 수정
  - 리뷰 목록 조회 시, 페이지당 20개를 반환하도록 수정
  - 리뷰 목록 조회 시, Emotion Table에서 감정 상태와 대표 감정 상태를 반환하도록 기능 추가
    - 최대값 비교 불가 시 `neutral`을 반환하도록  전달