### PR TITLE
Fix/#77 박스오피스 관련 DB 테이블 생성 오류

### DIFF
--- a/src/main/java/com/insidemovie/backend/api/movie/dto/boxoffice/DailyBoxOfficeResponseDTO.java
+++ b/src/main/java/com/insidemovie/backend/api/movie/dto/boxoffice/DailyBoxOfficeResponseDTO.java
@@ -19,7 +19,7 @@ public class DailyBoxOfficeResponseDTO {
             .base(BaseBoxOfficeItemDTO.builder()
                 .id(e.getId())
                 .rnum(e.getRnum())
-                .rank(e.getRank())
+                .rank(e.getMovieRank())
                 .rankInten(e.getRankInten())
                 .rankOldAndNew(e.getRankOldAndNew())
                 .movieCd(e.getMovieCd())

--- a/src/main/java/com/insidemovie/backend/api/movie/dto/boxoffice/WeeklyBoxOfficeResponseDTO.java
+++ b/src/main/java/com/insidemovie/backend/api/movie/dto/boxoffice/WeeklyBoxOfficeResponseDTO.java
@@ -18,7 +18,7 @@ public class WeeklyBoxOfficeResponseDTO {
             .base(BaseBoxOfficeItemDTO.builder()
                 .id(e.getId())
                 .rnum(e.getRnum())
-                .rank(e.getRank())
+                .rank(e.getMovieRank())
                 .rankInten(e.getRankInten())
                 .rankOldAndNew(e.getRankOldAndNew())
                 .movieCd(e.getMovieCd())

--- a/src/main/java/com/insidemovie/backend/api/movie/entity/DailyBoxOfficeEntity.java
+++ b/src/main/java/com/insidemovie/backend/api/movie/entity/DailyBoxOfficeEntity.java
@@ -19,7 +19,7 @@ public class DailyBoxOfficeEntity {
 
     private LocalDate targetDate;       // 조회 일자
     private String rnum;                // 순번
-    private String rank;                // 해당 일자 박스오피스 순위
+    private String movieRank;                // 해당 일자 박스오피스 순위
     private String rankInten;           // 전일 대비 순위 증감분
     private String rankOldAndNew;       // 랭킹 신규 진입 여부(OLD or NEW)
     private String movieCd;             // 영화 대표 코드

--- a/src/main/java/com/insidemovie/backend/api/movie/entity/WeeklyBoxOfficeEntity.java
+++ b/src/main/java/com/insidemovie/backend/api/movie/entity/WeeklyBoxOfficeEntity.java
@@ -18,7 +18,7 @@ public class WeeklyBoxOfficeEntity {
     @Column(name = "year_week_time")
     private String yearWeekTime;    // 연도+주차 (YYYYIWww)
     private String rnum;            // 순번
-    private String rank;            // 순위
+    private String movieRank;            // 순위
     private String rankInten;       // 순위 증감
     private String rankOldAndNew;   // 신규 진입 여부
     private String movieCd;         // 영화 코드

--- a/src/main/java/com/insidemovie/backend/api/movie/service/BoxOfficeService.java
+++ b/src/main/java/com/insidemovie/backend/api/movie/service/BoxOfficeService.java
@@ -98,7 +98,7 @@ public class BoxOfficeService {
             .map(node -> DailyBoxOfficeEntity.builder()
                 .targetDate(date)
                 .rnum(node.path("rnum").asText())
-                .rank(node.path("rank").asText())
+                .movieRank(node.path("rank").asText())
                 .rankInten(node.path("rankInten").asText())
                 .rankOldAndNew(node.path("rankOldAndNew").asText())
                 .movieCd(node.path("movieCd").asText())
@@ -187,7 +187,7 @@ public class BoxOfficeService {
             .map(node -> WeeklyBoxOfficeEntity.builder()
                 .yearWeekTime(yearWeek)                // DB에 저장할 연주차
                 .rnum(node.path("rnum").asText())
-                .rank(node.path("rank").asText())
+                .movieRank(node.path("rank").asText())
                 .rankInten(node.path("rankInten").asText())
                 .rankOldAndNew(node.path("rankOldAndNew").asText())
                 .movieCd(node.path("movieCd").asText())

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,8 +1,8 @@
 spring:
   config:
-
     activate:
       on-profile: local
+
   batch:
     jdbc:
       initialize-schema: never


### PR DESCRIPTION
## 📣 Related Issue
- close #77 

## 📝 Summary
- DB를 MySQL로 이전하는 과정에서 기존 `Daily(Weekly)BoxOfficeEntity`에서 선언되어 있던 영화의 순위(`rank`)가 MySQL의 예약어 `rank`와 충돌되어 테이블이 생성되지 않았음.
- 박스오피스 관련 테이블의 `rank`를 `movieRank`로 수정함.

## 🙏 Question & PR point
참고 PR: [MySQL 이전 작업](https://github.com/AutoeverInsideMovie/Insidemovie-BE/pull/68)