### PR TITLE
[FEAT] 내가 작성한 리뷰들의 감정 평균, 대표감정 조회 기능 구현

### DIFF
--- a/src/main/java/com/insidemovie/backend/api/member/controller/MemberController.java
+++ b/src/main/java/com/insidemovie/backend/api/member/controller/MemberController.java
@@ -141,5 +141,14 @@ public class MemberController {
         return ApiResponse.success(SuccessStatus.SEND_MY_REVIEW_SUCCESS, result);
     }
 
+    // 나의 리뷰 감정 평균 조회
+    @Operation(summary = "나의 감정 평균 조회", description = "로그인한 사용자의 리뷰 기반 감정 평균과 대표 감정을 조회합니다.")
+    @GetMapping("/emotion-summary")
+    public ResponseEntity<ApiResponse<EmotionAvgDTO>> getEmotionSummary(@AuthenticationPrincipal UserDetails userDetails) {
+        String email = userDetails.getUsername(); // 현재 로그인한 사용자 이메일
+        EmotionAvgDTO result = memberService.getMyEmotionSummary(email);
+        return ApiResponse.success(SuccessStatus.SEND_EMOTION_SUMMARY_SUCCESS, result);
+    }
+
 
 }

--- a/src/main/java/com/insidemovie/backend/api/member/dto/EmotionAvgDTO.java
+++ b/src/main/java/com/insidemovie/backend/api/member/dto/EmotionAvgDTO.java
@@ -1,0 +1,47 @@
+package com.insidemovie.backend.api.member.dto;
+
+import com.insidemovie.backend.api.constant.EmotionType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Map;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class EmotionAvgDTO {
+
+    @Builder.Default
+    private Double joy     = 0.0;
+    @Builder.Default
+    private Double sadness = 0.0;
+    @Builder.Default
+    private Double anger   = 0.0;
+    @Builder.Default
+    private Double fear    = 0.0;
+    @Builder.Default
+    private Double neutral = 0.0;
+
+    @Builder.Default
+    private EmotionType repEmotionType = EmotionType.NEUTRAL;
+
+    public EmotionAvgDTO(Double joy,
+                         Double sadness,
+                         Double anger,
+                         Double fear,
+                         Double neutral) {
+        this.joy             = joy != null ? joy : 0.0;
+        this.sadness         = sadness != null ? sadness : 0.0;
+        this.anger           = anger != null ? anger : 0.0;
+        this.fear            = fear != null ? fear : 0.0;
+        this.neutral         = neutral != null ? neutral : 0.0;
+        this.repEmotionType  = EmotionType.NEUTRAL;
+    }
+
+    public void setRepEmotionType(EmotionType repEmotionType) {
+        this.repEmotionType = repEmotionType;
+    }
+}

--- a/src/main/java/com/insidemovie/backend/api/member/entity/MemberEmotionSummary.java
+++ b/src/main/java/com/insidemovie/backend/api/member/entity/MemberEmotionSummary.java
@@ -1,11 +1,16 @@
 package com.insidemovie.backend.api.member.entity;
 
 import com.insidemovie.backend.api.constant.EmotionType;
+import com.insidemovie.backend.api.member.dto.EmotionAvgDTO;
 import jakarta.persistence.*;
 import lombok.*;
 
+import static org.apache.commons.lang3.math.NumberUtils.toFloat;
+
 @Entity
 @Getter
+@Builder
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "member_emotion_summary")
 public class MemberEmotionSummary {
@@ -19,12 +24,44 @@ public class MemberEmotionSummary {
     @JoinColumn(name = "member_id")
     private Member member;
 
-    private Float joy;
-    private Float sadness;
-    private Float anger;
-    private Float fear;
-    private Float neutral;
+    @Column(nullable = false)
+    private Float joy = 0.0f;
 
-    @Column(name = "rep_emotion_type")
-    private String repEmotionType;  // 대표 감정
+    @Column(nullable = false)
+    private Float sadness = 0.0f;
+
+    @Column(nullable = false)
+    private Float anger = 0.0f;
+
+    @Column(nullable = false)
+    private Float fear = 0.0f;
+
+    @Column(nullable = false)
+    private Float neutral = 0.0f;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private EmotionType repEmotionType = EmotionType.NEUTRAL;
+
+    @PrePersist
+    private void ensureDefaults() {
+        // null 방어는 사실 필요 없도록 primitive 초기화 사용
+        if (repEmotionType == null) {
+            repEmotionType = EmotionType.NEUTRAL;
+        }
+    }
+
+    // 평균 감정 정보를 DTO로부터 갱신
+    public void updateFromDTO(EmotionAvgDTO dto) {
+        this.joy            = dto.getJoy().floatValue();
+        this.sadness        = dto.getSadness().floatValue();
+        this.anger          = dto.getAnger().floatValue();
+        this.fear           = dto.getFear().floatValue();
+        this.neutral        = dto.getNeutral().floatValue();
+        this.repEmotionType = dto.getRepEmotionType();
+    }
+
+    private Float fromDouble(double value) {
+        return (float) value;
+    }
 }

--- a/src/main/java/com/insidemovie/backend/api/member/repository/MemberEmotionSummaryRepository.java
+++ b/src/main/java/com/insidemovie/backend/api/member/repository/MemberEmotionSummaryRepository.java
@@ -1,0 +1,9 @@
+package com.insidemovie.backend.api.member.repository;
+
+import com.insidemovie.backend.api.member.entity.MemberEmotionSummary;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberEmotionSummaryRepository extends JpaRepository<MemberEmotionSummary, Long> {
+
+
+}

--- a/src/main/java/com/insidemovie/backend/api/review/repository/EmotionRepository.java
+++ b/src/main/java/com/insidemovie/backend/api/review/repository/EmotionRepository.java
@@ -1,0 +1,29 @@
+package com.insidemovie.backend.api.review.repository;
+
+import com.insidemovie.backend.api.member.dto.EmotionAvgDTO;
+import com.insidemovie.backend.api.review.entity.Emotion;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface EmotionRepository extends JpaRepository<Emotion, Long> {
+    Optional<Emotion> findByReviewId(Long reviewId);
+
+    // 멤버가 작성한 모든 리뷰 감정의 평균값 계산
+    @Query("""
+        SELECT new com.insidemovie.backend.api.member.dto.EmotionAvgDTO(
+            COALESCE(AVG(e.joy), 0.0),
+            COALESCE(AVG(e.sadness), 0.0),
+            COALESCE(AVG(e.anger), 0.0),
+            COALESCE(AVG(e.fear), 0.0),
+            COALESCE(AVG(e.neutral), 0.0)
+        )
+        FROM Emotion e
+        WHERE e.review.member.id = :memberId
+    """)
+    Optional<EmotionAvgDTO> findAverageEmotionsByMemberId(@Param("memberId") Long memberId);
+
+}

--- a/src/main/java/com/insidemovie/backend/api/review/repository/EmotionRespository.java
+++ b/src/main/java/com/insidemovie/backend/api/review/repository/EmotionRespository.java
@@ -1,9 +1,0 @@
-package com.insidemovie.backend.api.review.repository;
-
-import com.insidemovie.backend.api.review.entity.Emotion;
-import org.springframework.data.jpa.repository.JpaRepository;
-import java.util.Optional;
-
-public interface EmotionRespository extends JpaRepository<Emotion, Long> {
-    Optional<Emotion> findByReviewId(Long reviewId);
-}

--- a/src/main/java/com/insidemovie/backend/api/review/service/ReviewService.java
+++ b/src/main/java/com/insidemovie/backend/api/review/service/ReviewService.java
@@ -8,7 +8,7 @@ import com.insidemovie.backend.api.review.dto.*;
 import com.insidemovie.backend.api.review.entity.Emotion;
 import com.insidemovie.backend.api.review.entity.Review;
 import com.insidemovie.backend.api.review.entity.ReviewLike;
-import com.insidemovie.backend.api.review.repository.EmotionRespository;
+import com.insidemovie.backend.api.review.repository.EmotionRepository;
 import com.insidemovie.backend.api.review.repository.ReviewLikeRepository;
 import com.insidemovie.backend.api.review.repository.ReviewRepository;
 import com.insidemovie.backend.common.exception.BadRequestException;
@@ -39,7 +39,7 @@ public class ReviewService {
     private final MemberRepository memberRepository;
     private final MovieRepository movieRepository;
     private final RestTemplate fastApiRestTemplate;
-    private final EmotionRespository emotionRespository;
+    private final EmotionRepository emotionRepository;
 
     // 리뷰 작성 메서드
     @Transactional
@@ -94,7 +94,7 @@ public class ReviewService {
                     .sadness(probabilities.get("sadness"))
                     .review(savedReview)
                     .build();
-            emotionRespository.save(emotion);
+            emotionRepository.save(emotion);
 
         } catch (RestClientException e) {
             throw new ExternalServiceException(ErrorStatus.EXTERNAL_SERVICE_ERROR.getMessage());
@@ -132,7 +132,7 @@ public class ReviewService {
             boolean myLike = (userId != null &&
                     reviewLikeRepository.existsByReview_IdAndMember_Id(review.getId(), userId));
 
-            Optional<Emotion> optEmotion = emotionRespository.findByReviewId(review.getId());
+            Optional<Emotion> optEmotion = emotionRepository.findByReviewId(review.getId());
             EmotionDTO emotionDTO = null;
             if (optEmotion.isPresent()) {
                 Emotion e = optEmotion.get();

--- a/src/main/java/com/insidemovie/backend/common/response/SuccessStatus.java
+++ b/src/main/java/com/insidemovie/backend/common/response/SuccessStatus.java
@@ -33,6 +33,7 @@ public enum SuccessStatus {
     SEND_DAILY_BOXOFFICE_SUCCESS(HttpStatus.OK, "일간 박스오피스 조회 성공"),
     SEND_WEEKLY_BOXOFFICE_SUCCESS(HttpStatus.OK, "주간 박스오피스 조회 성공"),
     LOGOUT_SUCCESS(HttpStatus.OK, "로그아웃 성공."),
+    SEND_EMOTION_SUMMARY_SUCCESS(HttpStatus.OK, "내 감정 평균 조회 성공"),
 
     /** 201 CREATED */
     CREATE_SAMPLE_SUCCESS(HttpStatus.CREATED, "샘플 등록 성공"),


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #65 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 사용자 리뷰를 기반으로 5가지 감정 평균을 계산하고, 가장 높은 값을 대표 감정으로 선정해서 `MemberEmotionSummary` 엔티티에 저장하는 기능

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
