### PR TITLE
[FIX] 카카오 회원가입, 로그인 로직 분리

### DIFF
--- a/src/main/java/com/insidemovie/backend/api/member/controller/MemberController.java
+++ b/src/main/java/com/insidemovie/backend/api/member/controller/MemberController.java
@@ -97,14 +97,14 @@ public class MemberController {
     // 카카오 회원가입
     @Operation(summary = "카카오 회원가입 API", description = "카카오 AccessToken으로 사용자 정보를 조회하고 회원가입을 처리합니다.")
     @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "카카오 로그인 성공")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "카카오 회원가입 성공")
     })
     @PostMapping("/kakao-signup")
-    public ResponseEntity<?> signup(@RequestBody Map<String, String> body) {
+    public ResponseEntity<ApiResponse<Void>> signup(@RequestBody Map<String, String> body) {
         String token = body.get("accessToken");
         String nickname = body.get("nickname");
-        Map<String, Object> result = memberService.kakaoSignup(token, nickname);
-        return ApiResponse.success(SuccessStatus.SEND_KAKAO_LOGIN_SUCCESS, result);
+        memberService.kakaoSignup(token, nickname);
+        return ApiResponse.success_only(SuccessStatus.SEND_KAKAO_REGISTER_SUCCESS);
     }
 
     // 사용자 정보 조회

--- a/src/main/java/com/insidemovie/backend/api/member/controller/MemberController.java
+++ b/src/main/java/com/insidemovie/backend/api/member/controller/MemberController.java
@@ -94,6 +94,19 @@ public class MemberController {
         return ApiResponse.success(SuccessStatus.SEND_KAKAO_LOGIN_SUCCESS, result);
     }
 
+    // 카카오 회원가입
+    @Operation(summary = "카카오 회원가입 API", description = "카카오 AccessToken으로 사용자 정보를 조회하고 회원가입을 처리합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "카카오 로그인 성공")
+    })
+    @PostMapping("/kakao-signup")
+    public ResponseEntity<?> signup(@RequestBody Map<String, String> body) {
+        String token = body.get("accessToken");
+        String nickname = body.get("nickname");
+        Map<String, Object> result = memberService.kakaoSignup(token, nickname);
+        return ApiResponse.success(SuccessStatus.SEND_KAKAO_LOGIN_SUCCESS, result);
+    }
+
     // 사용자 정보 조회
     @Operation(summary = "사용자 정보 조회 API", description = "사용자 정보를 조회합니다.")
     @GetMapping("/profile")

--- a/src/main/java/com/insidemovie/backend/common/config/security/SecurityConfig.java
+++ b/src/main/java/com/insidemovie/backend/common/config/security/SecurityConfig.java
@@ -62,7 +62,7 @@ public class SecurityConfig {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // 세션 사용 안함 (JWT 대비용)
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/h2-console/**", "/swagger-ui/**", "/v3/api-docs/**", "/swagger-resources/**", "/swagger-ui.html", "/webjars/**", "/api-doc").permitAll() // H2, Swagger 인증 허용
-                        .requestMatchers("/api/v1/member/signup", "/api/v1/member/reissue", "/api/v1/member/login", "/api/v1/member/kakao-accesstoken", "/api/v1/member/kakao-login", "/api/v1/member/token-reissue").permitAll() // 회원가입, 로그인 인증 허용
+                        .requestMatchers("/api/v1/member/signup", "/api/v1/member/reissue", "/api/v1/member/login", "/api/v1/member/kakao-accesstoken", "/api/v1/member/kakao-login", "/api/v1/member/kakao-signup", "/api/v1/member/token-reissue").permitAll() // 회원가입, 로그인 인증 허용
                         .requestMatchers(HttpMethod.POST, "/api/v1/report/**").hasRole("USER")
                         .requestMatchers("/api/v1/admin/**").hasRole("ADMIN")
                         .requestMatchers(HttpMethod.GET, "/api/v1/review/*").permitAll() // 영화에 대한 리뷰 목록 요청 허용

--- a/src/main/java/com/insidemovie/backend/common/response/ErrorStatus.java
+++ b/src/main/java/com/insidemovie/backend/common/response/ErrorStatus.java
@@ -11,6 +11,7 @@ public enum ErrorStatus {
     /** 400 BAD_REQUEST */
     VALIDATION_REQUEST_MISSING_EXCEPTION(HttpStatus.BAD_REQUEST, "요청 값이 입력되지 않았습니다."),
     ALREADY_EMAIL_EXIST_EXCEPTION(HttpStatus.BAD_REQUEST, "이미 가입된 이메일입니다."),
+    ALREADY_MEMBER_EXIST_EXCEPTION(HttpStatus.BAD_REQUEST, "이미 가입된 회원입니다."),
     PASSWORD_MISMATCH_EXCEPTION(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
     KAKAO_LOGIN_FAILED(HttpStatus.BAD_REQUEST, "카카오 로그인에 실패했습니다."),
     KAKAO_TOKEN_REQUEST_FAILED(HttpStatus.BAD_REQUEST, "카카오 토큰 요청에 실패했습니다."),

--- a/src/main/java/com/insidemovie/backend/common/response/SuccessStatus.java
+++ b/src/main/java/com/insidemovie/backend/common/response/SuccessStatus.java
@@ -13,6 +13,7 @@ public enum SuccessStatus {
     SEND_LOGIN_SUCCESS(HttpStatus.OK, "로그인 성공"),
     SEND_TOKEN_REISSUE_SUCCESS(HttpStatus.OK, "토큰 재발급 성공"),
     SEND_KAKAO_LOGIN_SUCCESS(HttpStatus.OK, "카카오 로그인 성공"),
+    SEND_KAKAO_REGISTER_SUCCESS(HttpStatus.OK, "카카오 회원가입 성공"),
     SEND_KAKAO_ACCESS_TOKEN_SUCCESS(HttpStatus.OK, "카카오 액세스 토큰 발급 성공"),
     SEND_REVIEW_SUCCESS(HttpStatus.OK,"리뷰 목록 조회 성공"),
     MODIFY_REVIEW_SUCCESS(HttpStatus.OK,"리뷰 수정 성공"),


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #91 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
카카오 회원가입과 로그인 로직을 분리하였습니다.

기존에는 카카오 로그인 시, 회원 정보가 없는 경우 자동으로 회원가입 처리 후 로그인 되었지만
추가 정보 입력을 위해 로직을 변경하였습니다.
- 카카오 로그인 : 회원 정보가 없는 경우 에러반환
- 카카오 회원가입 : 카카오에서 반환된 토큰 정보와 닉네임을 받아 회원가입 처리

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
