### PR TITLE
[FEAT] 맞춤 영화 제공 기능 구현

### DIFF
--- a/src/main/java/com/insidemovie/backend/api/member/controller/MemberController.java
+++ b/src/main/java/com/insidemovie/backend/api/member/controller/MemberController.java
@@ -1,9 +1,9 @@
 package com.insidemovie.backend.api.member.controller;
 
 import com.insidemovie.backend.api.member.dto.*;
+import com.insidemovie.backend.api.member.dto.emotion.EmotionAvgDTO;
 import com.insidemovie.backend.api.member.dto.emotion.MemberEmotionSummaryRequestDTO;
 import com.insidemovie.backend.api.member.dto.emotion.MemberEmotionSummaryResponseDTO;
-import com.insidemovie.backend.api.member.entity.Member;
 import com.insidemovie.backend.api.member.service.MemberService;
 import com.insidemovie.backend.api.member.service.OAuthService;
 import com.insidemovie.backend.api.movie.dto.MyMovieResponseDTO;

--- a/src/main/java/com/insidemovie/backend/api/member/dto/emotion/EmotionAvgDTO.java
+++ b/src/main/java/com/insidemovie/backend/api/member/dto/emotion/EmotionAvgDTO.java
@@ -1,12 +1,10 @@
-package com.insidemovie.backend.api.member.dto;
+package com.insidemovie.backend.api.member.dto.emotion;
 
 import com.insidemovie.backend.api.constant.EmotionType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.util.Map;
 
 @Getter
 @Builder

--- a/src/main/java/com/insidemovie/backend/api/member/entity/MemberEmotionSummary.java
+++ b/src/main/java/com/insidemovie/backend/api/member/entity/MemberEmotionSummary.java
@@ -1,7 +1,7 @@
 package com.insidemovie.backend.api.member.entity;
 
 import com.insidemovie.backend.api.constant.EmotionType;
-import com.insidemovie.backend.api.member.dto.EmotionAvgDTO;
+import com.insidemovie.backend.api.member.dto.emotion.EmotionAvgDTO;
 import jakarta.persistence.*;
 import lombok.*;
 

--- a/src/main/java/com/insidemovie/backend/api/member/service/MemberService.java
+++ b/src/main/java/com/insidemovie/backend/api/member/service/MemberService.java
@@ -5,6 +5,7 @@ import com.insidemovie.backend.api.constant.Authority;
 import com.insidemovie.backend.api.constant.EmotionType;
 import com.insidemovie.backend.api.jwt.JwtProvider;
 import com.insidemovie.backend.api.member.dto.*;
+import com.insidemovie.backend.api.member.dto.emotion.EmotionAvgDTO;
 import com.insidemovie.backend.api.member.dto.emotion.MemberEmotionSummaryRequestDTO;
 import com.insidemovie.backend.api.member.dto.emotion.MemberEmotionSummaryResponseDTO;
 import com.insidemovie.backend.api.member.entity.Member;
@@ -19,7 +20,6 @@ import com.insidemovie.backend.common.response.ErrorStatus;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 
-import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;

--- a/src/main/java/com/insidemovie/backend/api/movie/controller/MovieController.java
+++ b/src/main/java/com/insidemovie/backend/api/movie/controller/MovieController.java
@@ -1,7 +1,7 @@
 package com.insidemovie.backend.api.movie.controller;
 
 
-import com.insidemovie.backend.api.member.dto.EmotionAvgDTO;
+import com.insidemovie.backend.api.member.dto.emotion.EmotionAvgDTO;
 import com.insidemovie.backend.api.movie.dto.MovieDetailResDto;
 import com.insidemovie.backend.api.movie.dto.MovieSearchResDto;
 import com.insidemovie.backend.api.movie.dto.PageResDto;

--- a/src/main/java/com/insidemovie/backend/api/movie/entity/MovieEmotionSummary.java
+++ b/src/main/java/com/insidemovie/backend/api/movie/entity/MovieEmotionSummary.java
@@ -1,7 +1,7 @@
 package com.insidemovie.backend.api.movie.entity;
 
 import com.insidemovie.backend.api.constant.EmotionType;
-import com.insidemovie.backend.api.member.dto.EmotionAvgDTO;
+import com.insidemovie.backend.api.member.dto.emotion.EmotionAvgDTO;
 import jakarta.persistence.*;
 import lombok.*;
 

--- a/src/main/java/com/insidemovie/backend/api/movie/service/MovieService.java
+++ b/src/main/java/com/insidemovie/backend/api/movie/service/MovieService.java
@@ -4,7 +4,7 @@ import com.insidemovie.backend.api.movie.dto.MovieSearchResDto;
 import com.insidemovie.backend.api.movie.dto.PageResDto;
 import com.insidemovie.backend.api.constant.EmotionType;
 import com.insidemovie.backend.api.constant.MovieLanguage;
-import com.insidemovie.backend.api.member.dto.EmotionAvgDTO;
+import com.insidemovie.backend.api.member.dto.emotion.EmotionAvgDTO;
 
 import com.insidemovie.backend.api.movie.dto.TmdbGenreResponseDto;
 import com.insidemovie.backend.api.movie.dto.emotion.MovieEmotionSummaryResponseDTO;

--- a/src/main/java/com/insidemovie/backend/api/recommend/controller/EmotionRecommendationController.java
+++ b/src/main/java/com/insidemovie/backend/api/recommend/controller/EmotionRecommendationController.java
@@ -1,0 +1,31 @@
+package com.insidemovie.backend.api.recommend.controller;
+
+import com.insidemovie.backend.api.movie.repository.MovieEmotionSummaryRepository;
+import com.insidemovie.backend.api.recommend.dto.EmotionRequestDTO;
+import com.insidemovie.backend.api.recommend.dto.MovieRecommendationDTO;
+import com.insidemovie.backend.api.recommend.service.EmotionRecommendationService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/recommend")
+@Tag(name = "Recommend", description = "추천 영화 관련 API")
+@RequiredArgsConstructor
+public class EmotionRecommendationController {
+
+    private final MovieEmotionSummaryRepository movieEmotionSummaryRepository;
+    private final EmotionRecommendationService recommendationService;
+
+    @Operation(summary = "맞춤 영화 조회", description = "감정 상태로 영화를 추천합니다")
+    @PostMapping("/emotion")
+    public List<MovieRecommendationDTO> recommendMovies(@RequestBody EmotionRequestDTO emotionRequest) {
+        return recommendationService.recommendByEmotion(emotionRequest);
+    }
+}

--- a/src/main/java/com/insidemovie/backend/api/recommend/dto/EmotionRequestDTO.java
+++ b/src/main/java/com/insidemovie/backend/api/recommend/dto/EmotionRequestDTO.java
@@ -1,0 +1,13 @@
+package com.insidemovie.backend.api.recommend.dto;
+
+import lombok.Data;
+
+@Data
+public class EmotionRequestDTO {
+
+    private double joy;
+    private double anger;
+    private double fear;
+    private double neutral;
+    private double sadness;
+}

--- a/src/main/java/com/insidemovie/backend/api/recommend/dto/MovieRecommendationDTO.java
+++ b/src/main/java/com/insidemovie/backend/api/recommend/dto/MovieRecommendationDTO.java
@@ -1,0 +1,22 @@
+package com.insidemovie.backend.api.recommend.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.insidemovie.backend.api.constant.EmotionType;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class MovieRecommendationDTO {
+
+    private Long movieId;
+    private String title;
+    private String posterPath;
+    private double voteAverage;
+
+    private EmotionType dominantEmotion;  // 대표 감정
+    private double dominantEmotionRatio;  // 대표 감정 퍼센트
+
+    @JsonIgnore
+    private double similarity;  // 유사도
+}

--- a/src/main/java/com/insidemovie/backend/api/recommend/service/EmotionRecommendationService.java
+++ b/src/main/java/com/insidemovie/backend/api/recommend/service/EmotionRecommendationService.java
@@ -1,0 +1,105 @@
+package com.insidemovie.backend.api.recommend.service;
+
+import com.insidemovie.backend.api.movie.entity.MovieEmotionSummary;
+import com.insidemovie.backend.api.movie.repository.MovieEmotionSummaryRepository;
+import com.insidemovie.backend.api.recommend.dto.EmotionRequestDTO;
+import com.insidemovie.backend.api.recommend.dto.MovieRecommendationDTO;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class EmotionRecommendationService {
+
+    private final MovieEmotionSummaryRepository movieEmotionSummaryRepository;
+
+    // 사용자의 감정 벡터를 기반으로 영화 추천 리스트 반환
+    public List<MovieRecommendationDTO> recommendByEmotion(EmotionRequestDTO userEmotion) {
+
+        // 사용자 감정 벡터 정규화 (총합이 100이 아니여서)
+        Map<String, Double> userVector = normalize(Map.of(
+                "joy", userEmotion.getJoy(),
+                "anger", userEmotion.getAnger(),
+                "fear", userEmotion.getFear(),
+                "neutral", userEmotion.getNeutral(),
+                "sadness", userEmotion.getSadness()
+        ));
+
+        // DB에서 영화 전체 감정 벡터 불러오기
+        List<MovieEmotionSummary> allMovies = movieEmotionSummaryRepository.findAll();
+
+        // 각 영화의 감정 벡터와 유사도 계산
+        return allMovies.stream()
+                .map(movie -> {
+
+                    // 영화 감정 벡터도 정규화
+                    Map<String, Double> movieVector = normalize(Map.of(
+                            "joy", movie.getJoy().doubleValue(),
+                            "sadness", movie.getSadness().doubleValue(),
+                            "anger", movie.getAnger().doubleValue(),
+                            "fear", movie.getFear().doubleValue(),
+                            "neutral", movie.getNeutral().doubleValue()
+                    ));
+
+                    // 유사도 계산
+                    double similarity = cosineSimilarity(userVector, movieVector);
+
+                    // 대표 감정 비율 가져오기
+                    double dominantRatio = switch (movie.getDominantEmotion()) {
+                        case JOY -> movie.getJoy().doubleValue();
+                        case SADNESS -> movie.getSadness().doubleValue();
+                        case ANGER -> movie.getAnger().doubleValue();
+                        case FEAR -> movie.getFear().doubleValue();
+                        case NEUTRAL -> movie.getNeutral().doubleValue();
+                    };
+
+                    return new MovieRecommendationDTO(
+                            movie.getMovieId(),
+                            movie.getMovie().getTitle(),
+                            movie.getMovie().getPosterPath(),
+                            movie.getMovie().getVoteAverage(),
+                            movie.getDominantEmotion(),
+                            dominantRatio,
+                            similarity
+                    );
+                })
+
+                // 유사도 높은 순으로 정렬
+                .sorted(Comparator.comparingDouble(MovieRecommendationDTO::getSimilarity).reversed()) // 유사도 높은 순
+                .limit(5) // 상위 5개만 추천
+                .collect(Collectors.toList());
+    }
+
+    // 벡터 정규화
+    private Map<String, Double> normalize(Map<String, Double> vector) {
+        double sum = vector.values().stream().mapToDouble(Double::doubleValue).sum();
+        return vector.entrySet().stream()
+                .collect(Collectors.toMap(
+                        Map.Entry::getKey,
+                        e -> sum == 0 ? 0.0 : e.getValue() / sum
+                ));
+    }
+
+    // 코사인 유사도 계산
+    private double cosineSimilarity(Map<String, Double> v1, Map<String, Double> v2) {
+        double dot = 0.0;
+        double norm1 = 0.0;
+        double norm2 = 0.0;
+
+        for (String key : v1.keySet()) {
+            double a = v1.get(key);
+            double b = v2.getOrDefault(key, 0.0);
+            dot += a * b;
+            norm1 += a * a;
+            norm2 += b * b;
+        }
+
+        return (norm1 == 0 || norm2 == 0) ? 0.0 : dot / (Math.sqrt(norm1) * Math.sqrt(norm2));
+    }
+}

--- a/src/main/java/com/insidemovie/backend/api/review/repository/EmotionRepository.java
+++ b/src/main/java/com/insidemovie/backend/api/review/repository/EmotionRepository.java
@@ -1,12 +1,11 @@
 package com.insidemovie.backend.api.review.repository;
 
-import com.insidemovie.backend.api.member.dto.EmotionAvgDTO;
+import com.insidemovie.backend.api.member.dto.emotion.EmotionAvgDTO;
 import com.insidemovie.backend.api.review.entity.Emotion;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.util.List;
 import java.util.Optional;
 
 public interface EmotionRepository extends JpaRepository<Emotion, Long> {

--- a/src/main/java/com/insidemovie/backend/api/review/repository/EmotionRepository.java
+++ b/src/main/java/com/insidemovie/backend/api/review/repository/EmotionRepository.java
@@ -13,7 +13,7 @@ public interface EmotionRepository extends JpaRepository<Emotion, Long> {
 
     // 멤버가 작성한 모든 리뷰 감정의 평균값 계산
     @Query("""
-        SELECT new com.insidemovie.backend.api.member.dto.EmotionAvgDTO(
+        SELECT new com.insidemovie.backend.api.member.dto.emotion.EmotionAvgDTO(
             COALESCE(AVG(e.joy), 0.0),
             COALESCE(AVG(e.sadness), 0.0),
             COALESCE(AVG(e.anger), 0.0),
@@ -26,7 +26,7 @@ public interface EmotionRepository extends JpaRepository<Emotion, Long> {
     Optional<EmotionAvgDTO> findAverageEmotionsByMemberId(@Param("memberId") Long memberId);
 
     @Query("""
-        SELECT new com.insidemovie.backend.api.member.dto.EmotionAvgDTO(
+        SELECT new com.insidemovie.backend.api.member.dto.emotion.EmotionAvgDTO(
             COALESCE(AVG(e.joy), 0.0),
             COALESCE(AVG(e.sadness), 0.0),
             COALESCE(AVG(e.anger), 0.0),


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #117 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- recommend 도메인을 따로 구성해서 /api/recommend/emotion 경로로 감정 기반 맞춤 영화 추천 API 구현
- 사용자 감정 벡터와 영화 감정 요약 벡터 간 코사인 유사도를 계산하여 상위 5개 영화 추천

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 프론트에서 감정 값이 0~100 사이의 실수(Double) 형태로 들어오도록 했습니다.
- 추천 영화도 똑같이 /api/recommend/genre 이런 식으로 하면 될 것 같습니다.
- 현재 리뷰 및 감정 데이터가 충분하지 않아 추천 정확도는 아직 검증되지 않았습니다.

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
