### PR TITLE
[FIX] 관리자 대시보드에 누적 통계 (일별/월별) 추가 구현

### DIFF
--- a/src/main/java/com/insidemovie/backend/api/admin/dto/AdminDashboardDTO.java
+++ b/src/main/java/com/insidemovie/backend/api/admin/dto/AdminDashboardDTO.java
@@ -25,4 +25,12 @@ public class AdminDashboardDTO {
     private List<TimeCountDTO> dailyReportCounts;
     private List<TimeCountDTO> monthlyReportCounts;
 
+    // 월별, 일별 누적 수
+    private List<TimeCountDTO> dailyMemberCumulativeCounts;
+    private List<TimeCountDTO> monthlyMemberCumulativeCounts;
+    private List<TimeCountDTO> dailyReviewCumulativeCounts;
+    private List<TimeCountDTO> monthlyReviewCumulativeCounts;
+    private List<TimeCountDTO> dailyReportCumulativeCounts;
+    private List<TimeCountDTO> monthlyReportCumulativeCounts;
+
 }

--- a/src/main/java/com/insidemovie/backend/api/admin/service/AdminService.java
+++ b/src/main/java/com/insidemovie/backend/api/admin/service/AdminService.java
@@ -19,7 +19,13 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.YearMonth;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.IntStream;
 
 @Service
 @RequiredArgsConstructor
@@ -95,21 +101,54 @@ public class AdminService {
     @Transactional
     public AdminDashboardDTO getDashboardSummary() {
 
-        Long totalMembers = memberRepository.count();
-        Long bannedMembers = memberRepository.countByIsBannedTrue();
-        Long totalReviews = reviewRepository.count();
-        Long concealedReviews = reviewRepository.countByIsConcealedTrue();
-        Long unprocessedReports = reportRepository.countByStatus(ReportStatus.UNPROCESSED);
+        LocalDate today = LocalDate.now();
+        LocalDate yesterday = today.minusDays(1);
+        YearMonth thisMonth = YearMonth.now();
 
-        // 일별/월별 통계 변환
-        List<TimeCountDTO> dailyMemberCounts = mapToTimeCountDTO(memberRepository.countMembersDaily());
-        List<TimeCountDTO> monthlyMemberCounts = mapToTimeCountDTO(memberRepository.countMembersMonthly());
+        // 어제 기준 30일
+        LocalDate startDailyBase = yesterday.minusDays(29); // 30일 전 (누적 첫 날)
+        LocalDateTime dailyStart = startDailyBase.atStartOfDay();
+        LocalDateTime dailyEnd = today.atStartOfDay();     // 오늘 0시 (어제 포함)
 
-        List<TimeCountDTO> dailyReviewCounts = mapToTimeCountDTO(reviewRepository.countReviewsDaily());
-        List<TimeCountDTO> monthlyReviewCounts = mapToTimeCountDTO(reviewRepository.countReviewsMonthly());
+        // 지난달까지 12개월
+        YearMonth firstMonth = thisMonth.minusMonths(12);    // 12개월 전
+        LocalDateTime monthlyStart = firstMonth.atDay(1).atStartOfDay();
+        LocalDateTime monthlyEnd = thisMonth.atDay(1).atStartOfDay(); // 이번달 1일 (이번달 제외)
 
-        List<TimeCountDTO> dailyReportCounts = mapToTimeCountDTO(reportRepository.countReportsDaily());
-        List<TimeCountDTO> monthlyReportCounts = mapToTimeCountDTO(reportRepository.countReportsMonthly());
+        // 날짜, 월 리스트 생성 (오래된 → 최신)
+        List<LocalDate> last30Days = startDailyBase.datesUntil(yesterday.plusDays(1)).toList(); // 30개
+        List<YearMonth> last12Months = IntStream.rangeClosed(1, 12)
+                .mapToObj(i -> thisMonth.minusMonths(13 - i)) // 12..1 → 12개월 전 ~ 지난달
+                .toList();
+
+        // 신규 일별
+        List<TimeCountDTO> rawDailyNewMembers = mapToDTO(memberRepository.countMembersDaily(dailyStart, dailyEnd));
+        List<TimeCountDTO> rawDailyNewReviews = mapToDTO(reviewRepository.countReviewsDaily(dailyStart, dailyEnd));
+        List<TimeCountDTO> rawDailyNewReports = mapToDTO(reportRepository.countReportsDaily(dailyStart, dailyEnd));
+
+        // 신규 월별
+        List<TimeCountDTO> rawMonthlyNewMembers = mapToDTO(memberRepository.countMembersMonthly(monthlyStart, monthlyEnd));
+        List<TimeCountDTO> rawMonthlyNewReviews = mapToDTO(reviewRepository.countReviewsMonthly(monthlyStart, monthlyEnd));
+        List<TimeCountDTO> rawMonthlyNewReports = mapToDTO(reportRepository.countReportsMonthly(monthlyStart, monthlyEnd));
+
+        // (옵션) 신규 배열도 0 채워서 “고정 길이”로 만들고 싶으면 fill 사용
+        List<TimeCountDTO> dailyNewMembers = fillDailyZeros(last30Days, rawDailyNewMembers);
+        List<TimeCountDTO> dailyNewReviews = fillDailyZeros(last30Days, rawDailyNewReviews);
+        List<TimeCountDTO> dailyNewReports = fillDailyZeros(last30Days, rawDailyNewReports);
+
+        List<TimeCountDTO> monthlyNewMembers = fillMonthlyZeros(last12Months, rawMonthlyNewMembers);
+        List<TimeCountDTO> monthlyNewReviews = fillMonthlyZeros(last12Months, rawMonthlyNewReviews);
+        List<TimeCountDTO> monthlyNewReports = fillMonthlyZeros(last12Months, rawMonthlyNewReports);
+
+        // 누적 일별
+        List<TimeCountDTO> dailyMemberCumulative = buildDailyCumulative(last30Days, memberRepository::countByCreatedAtLessThan);
+        List<TimeCountDTO> dailyReviewCumulative = buildDailyCumulative(last30Days, reviewRepository::countByCreatedAtLessThan);
+        List<TimeCountDTO> dailyReportCumulative = buildDailyCumulative(last30Days, reportRepository::countByCreatedAtLessThan);
+
+        // 누적 월별
+        List<TimeCountDTO> monthlyMemberCumulative = buildMonthlyCumulative(last12Months, memberRepository::countByCreatedAtLessThan);
+        List<TimeCountDTO> monthlyReviewCumulative = buildMonthlyCumulative(last12Months, reviewRepository::countByCreatedAtLessThan);
+        List<TimeCountDTO> monthlyReportCumulative = buildMonthlyCumulative(last12Months, reportRepository::countByCreatedAtLessThan);
 
         return AdminDashboardDTO.builder()
                 .totalMembers(memberRepository.count())
@@ -118,21 +157,77 @@ public class AdminService {
                 .concealedReviews(reviewRepository.countByIsConcealedTrue())
                 .unprocessedReports(reportRepository.countByStatus(ReportStatus.UNPROCESSED))
 
-                .dailyMemberCounts(dailyMemberCounts)
-                .monthlyMemberCounts(monthlyMemberCounts)
-                .dailyReviewCounts(dailyReviewCounts)
-                .monthlyReviewCounts(monthlyReviewCounts)
-                .dailyReportCounts(dailyReportCounts)
-                .monthlyReportCounts(monthlyReportCounts)
+                // 신규(증가분)
+                .dailyMemberCounts(dailyNewMembers)
+                .dailyReviewCounts(dailyNewReviews)
+                .dailyReportCounts(dailyNewReports)
+                .monthlyMemberCounts(monthlyNewMembers)
+                .monthlyReviewCounts(monthlyNewReviews)
+                .monthlyReportCounts(monthlyNewReports)
+
+                // 전체(누적)
+                .dailyMemberCumulativeCounts(dailyMemberCumulative)
+                .dailyReviewCumulativeCounts(dailyReviewCumulative)
+                .dailyReportCumulativeCounts(dailyReportCumulative)
+                .monthlyMemberCumulativeCounts(monthlyMemberCumulative)
+                .monthlyReviewCumulativeCounts(monthlyReviewCumulative)
+                .monthlyReportCumulativeCounts(monthlyReportCumulative)
                 .build();
     }
 
-    private List<TimeCountDTO> mapToTimeCountDTO(List<Object[]> results) {
-        return results.stream()
-                .map(obj -> TimeCountDTO.builder()
-                        .date(obj[0].toString())
-                        .count(((Number) obj[1]).longValue())
-                        .build()
-                ).toList();
+    private List<TimeCountDTO> mapToDTO(List<Object[]> raw) {
+        return raw.stream()
+                .map(r -> TimeCountDTO.builder()
+                        .date(r[0].toString())
+                        .count(((Number) r[1]).longValue())
+                        .build())
+                .toList();
     }
+
+    // 신규 일별 없는 날짜는 0 채우기
+    private List<TimeCountDTO> fillDailyZeros(List<LocalDate> days, List<TimeCountDTO> raw) {
+        Map<String, Long> map = raw.stream()
+                .collect(java.util.stream.Collectors.toMap(TimeCountDTO::getDate, TimeCountDTO::getCount));
+        return days.stream()
+                .map(d -> TimeCountDTO.builder()
+                        .date(d.toString())
+                        .count(map.getOrDefault(d.toString(), 0L))
+                        .build())
+                .toList();
+    }
+
+    // 신규 월별 없는 월은 0 채우기
+    private List<TimeCountDTO> fillMonthlyZeros(List<YearMonth> months, List<TimeCountDTO> raw) {
+        Map<String, Long> map = raw.stream()
+                .collect(java.util.stream.Collectors.toMap(TimeCountDTO::getDate, TimeCountDTO::getCount));
+        return months.stream()
+                .map(ym -> TimeCountDTO.builder()
+                        .date(ym.toString())
+                        .count(map.getOrDefault(ym.toString(), 0L))
+                        .build())
+                .toList();
+    }
+
+    // 누적 일별
+    private List<TimeCountDTO> buildDailyCumulative(List<LocalDate> days,
+                                                    Function<LocalDateTime, Long> countFn) {
+        return days.stream()
+                .map(d -> TimeCountDTO.builder()
+                        .date(d.toString())
+                        .count(countFn.apply(d.plusDays(1).atStartOfDay()))
+                        .build())
+                .toList();
+    }
+
+    // 누적 월별
+    private List<TimeCountDTO> buildMonthlyCumulative(List<YearMonth> months,
+                                                      Function<LocalDateTime, Long> countFn) {
+        return months.stream()
+                .map(ym -> TimeCountDTO.builder()
+                        .date(ym.toString())
+                        .count(countFn.apply(ym.plusMonths(1).atDay(1).atStartOfDay()))
+                        .build())
+                .toList();
+    }
+
 }


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #124 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 관리자 대시보드에 어제 기준 최근 30일, 지난달 기준 최근 12개월의 신규/누적(전체) 추가 구현 

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
