### PR TITLE
[FIX] 박스오피스 스케줄러 관련 서비스 로직 수정 및 박스오피스 영화의 상세보기 API 기능 추가

### DIFF
--- a/src/main/java/com/insidemovie/backend/api/movie/controller/BoxOfficeController.java
+++ b/src/main/java/com/insidemovie/backend/api/movie/controller/BoxOfficeController.java
@@ -1,5 +1,6 @@
 package com.insidemovie.backend.api.movie.controller;
 
+import com.insidemovie.backend.api.movie.dto.MovieDetailResDto;
 import com.insidemovie.backend.api.movie.dto.boxoffice.BoxOfficeListDTO;
 import com.insidemovie.backend.api.movie.dto.boxoffice.DailyBoxOfficeResponseDTO;
 import com.insidemovie.backend.api.movie.dto.boxoffice.WeeklyBoxOfficeResponseDTO;
@@ -14,6 +15,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/boxoffice")
@@ -42,6 +44,27 @@ public class BoxOfficeController {
         );
     }
 
+    /**
+     * 일간 박스오피스 영화 한 편의 상세정보 조회
+     */
+    @GetMapping("/daily/detail")
+    public ResponseEntity<ApiResponse<MovieDetailResDto>> getDailyMovieDetail(
+        @RequestParam Long movieId,
+        @RequestParam(value="targetDt", required=false, defaultValue="") String targetDt
+    ) {
+        String defaultDt = targetDt.isBlank()
+            ? LocalDate.now().minusDays(1).format(FMT)
+            : targetDt;
+
+        MovieDetailResDto dto = boxOfficeService
+            .getDailyMovieDetailByMovieId(movieId, defaultDt);
+
+        return ApiResponse.success(
+            SuccessStatus.SEND_BOXOFFICE_MOVIE_DETAIL_SUCCESS,
+            dto
+        );
+    }
+
     // 주간 박스오피스 조회
     @GetMapping("/weekly")
     public ResponseEntity<ApiResponse<BoxOfficeListDTO<WeeklyBoxOfficeResponseDTO>>> getWeekly(
@@ -54,6 +77,28 @@ public class BoxOfficeController {
         return ApiResponse.success(
             SuccessStatus.SEND_WEEKLY_BOXOFFICE_SUCCESS,
             response
+        );
+    }
+
+    /**
+     * 주간 박스오피스 영화 한 편의 상세정보 조회
+     */
+    @GetMapping("/weekly/detail")
+    public ResponseEntity<ApiResponse<MovieDetailResDto>> getWeeklyMovieDetail(
+        @RequestParam Long movieId,
+        @RequestParam(value="targetDt", required=false, defaultValue="") String targetDt,
+        @RequestParam(defaultValue="0") String weekGb
+    ) {
+        String defaultDt = targetDt.isBlank()
+            ? LocalDate.now().minusWeeks(1).format(FMT)
+            : targetDt;
+
+        MovieDetailResDto dto = boxOfficeService
+            .getWeeklyMovieDetailByMovieId(movieId, defaultDt, weekGb);
+
+        return ApiResponse.success(
+            SuccessStatus.SEND_BOXOFFICE_MOVIE_DETAIL_SUCCESS,
+            dto
         );
     }
 }

--- a/src/main/java/com/insidemovie/backend/api/movie/dto/boxoffice/BoxOfficeListDTO.java
+++ b/src/main/java/com/insidemovie/backend/api/movie/dto/boxoffice/BoxOfficeListDTO.java
@@ -9,6 +9,6 @@ import java.util.List;
 @Builder
 public class BoxOfficeListDTO<T> {
     private String boxofficeType;
-    private String showRange;
+    private String targetDt;
     private List<T> items; // DailyBoxOfficeResponseDTO 또는 WeeklyBoxOfficeResponseDTO
 }

--- a/src/main/java/com/insidemovie/backend/api/movie/dto/boxoffice/DailyBoxOfficeResponseDTO.java
+++ b/src/main/java/com/insidemovie/backend/api/movie/dto/boxoffice/DailyBoxOfficeResponseDTO.java
@@ -10,9 +10,6 @@ import java.time.LocalDate;
 @Builder
 public class DailyBoxOfficeResponseDTO {
     private BaseBoxOfficeItemDTO base;
-    private LocalDate targetDate;
-    private String boxofficeType;
-    private String showRange;
 
     public static DailyBoxOfficeResponseDTO fromEntity(DailyBoxOfficeEntity e) {
         return DailyBoxOfficeResponseDTO.builder()
@@ -37,9 +34,6 @@ public class DailyBoxOfficeResponseDTO {
                 .scrnCnt(e.getScrnCnt())
                 .showCnt(e.getShowCnt())
                 .build())
-            .targetDate(e.getTargetDate())
-            .boxofficeType("일별")
-            .showRange(e.getTargetDate().toString() + "~" + e.getTargetDate().toString())
             .build();
     }
 }

--- a/src/main/java/com/insidemovie/backend/api/movie/dto/boxoffice/DailyBoxOfficeResponseDTO.java
+++ b/src/main/java/com/insidemovie/backend/api/movie/dto/boxoffice/DailyBoxOfficeResponseDTO.java
@@ -9,6 +9,7 @@ import java.time.LocalDate;
 @Getter
 @Builder
 public class DailyBoxOfficeResponseDTO {
+    private Long movieId;
     private BaseBoxOfficeItemDTO base;
 
     public static DailyBoxOfficeResponseDTO fromEntity(DailyBoxOfficeEntity e) {

--- a/src/main/java/com/insidemovie/backend/api/movie/dto/boxoffice/WeeklyBoxOfficeResponseDTO.java
+++ b/src/main/java/com/insidemovie/backend/api/movie/dto/boxoffice/WeeklyBoxOfficeResponseDTO.java
@@ -9,9 +9,6 @@ import lombok.Getter;
 @Builder
 public class WeeklyBoxOfficeResponseDTO {
     private BaseBoxOfficeItemDTO base;
-    private String yearWeekTime;
-    private String boxofficeType;
-    private String showRange;
 
     public static WeeklyBoxOfficeResponseDTO fromEntity(WeeklyBoxOfficeEntity e) {
         return WeeklyBoxOfficeResponseDTO.builder()
@@ -36,7 +33,6 @@ public class WeeklyBoxOfficeResponseDTO {
                 .scrnCnt(e.getScrnCnt())
                 .showCnt(e.getShowCnt())
                 .build())
-            .yearWeekTime(e.getYearWeekTime())
             .build();
     }
 }

--- a/src/main/java/com/insidemovie/backend/api/movie/dto/boxoffice/WeeklyBoxOfficeResponseDTO.java
+++ b/src/main/java/com/insidemovie/backend/api/movie/dto/boxoffice/WeeklyBoxOfficeResponseDTO.java
@@ -9,6 +9,7 @@ import lombok.Getter;
 @Builder
 public class WeeklyBoxOfficeResponseDTO {
     private BaseBoxOfficeItemDTO base;
+    private Long movieId;
 
     public static WeeklyBoxOfficeResponseDTO fromEntity(WeeklyBoxOfficeEntity e) {
         return WeeklyBoxOfficeResponseDTO.builder()

--- a/src/main/java/com/insidemovie/backend/api/movie/entity/boxoffice/DailyBoxOfficeEntity.java
+++ b/src/main/java/com/insidemovie/backend/api/movie/entity/boxoffice/DailyBoxOfficeEntity.java
@@ -18,13 +18,13 @@ public class DailyBoxOfficeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @OneToOne(fetch = FetchType.LAZY, optional = true)
+    @ManyToOne(fetch = FetchType.LAZY, optional = true)
     @JoinColumn(name = "tmdb_id", referencedColumnName = "tmdb_id")
     private Movie movie;
 
     private LocalDate targetDate;       // 조회 일자
     private String rnum;                // 순번
-    private String movieRank;                // 해당 일자 박스오피스 순위
+    private String movieRank;           // 해당 일자 박스오피스 순위
     private String rankInten;           // 전일 대비 순위 증감분
     private String rankOldAndNew;       // 랭킹 신규 진입 여부(OLD or NEW)
     private String movieCd;             // 영화 대표 코드
@@ -34,10 +34,31 @@ public class DailyBoxOfficeEntity {
     private String salesInten;          // 전일 대비 매출액 증감분
     private String salesChange;         // 전일 대비 매출액 증감 비율
     private String salesAcc;            // 누적 매출액
+    private String salesAmt;            // 매출액
     private String audiCnt;             // 해당일 관객수
     private String audiInten;           // 전일 대비 관객수 증감분
     private String audiChange;          // 전일 대비 관객수 증감 비율
     private String audiAcc;             // 누적 관객수
     private String scrnCnt;             // 해당일 상영한 스크린 수
     private String showCnt;             // 해당일 상영된 횟수
+
+    public void updateFrom(DailyBoxOfficeEntity other) {
+        this.rnum            = other.rnum;
+        this.movieRank       = other.movieRank;
+        this.rankInten       = other.rankInten;
+        this.rankOldAndNew   = other.rankOldAndNew;
+        this.openDate        = other.openDate;
+        this.salesShare      = other.salesShare;
+        this.salesInten      = other.salesInten;
+        this.salesChange     = other.salesChange;
+        this.salesAcc        = other.salesAcc;
+        this.audiCnt         = other.audiCnt;
+        this.audiInten       = other.audiInten;
+        this.audiChange      = other.audiChange;
+        this.audiAcc         = other.audiAcc;
+        this.scrnCnt         = other.scrnCnt;
+        this.showCnt         = other.showCnt;
+        this.salesAmt        = other.salesAmt;
+        this.salesShare      = other.salesShare;
+    }
 }

--- a/src/main/java/com/insidemovie/backend/api/movie/entity/boxoffice/WeeklyBoxOfficeEntity.java
+++ b/src/main/java/com/insidemovie/backend/api/movie/entity/boxoffice/WeeklyBoxOfficeEntity.java
@@ -16,7 +16,7 @@ public class WeeklyBoxOfficeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @OneToOne(fetch = FetchType.LAZY, optional = true)
+    @ManyToOne(fetch = FetchType.LAZY, optional = true)
     @JoinColumn(name = "tmdb_id", referencedColumnName = "tmdb_id")
     private Movie movie;
 
@@ -40,4 +40,23 @@ public class WeeklyBoxOfficeEntity {
     private String audiAcc;         // 누적 관객수
     private String scrnCnt;         // 상영 스크린 수
     private String showCnt;         // 상영 횟수
+
+    public void updateFrom(WeeklyBoxOfficeEntity other) {
+        this.rnum            = other.rnum;
+        this.movieRank       = other.movieRank;
+        this.rankInten       = other.rankInten;
+        this.rankOldAndNew   = other.rankOldAndNew;
+        this.openDt          = other.openDt;
+        this.salesShare      = other.salesShare;
+        this.salesInten      = other.salesInten;
+        this.salesChange     = other.salesChange;
+        this.salesAcc        = other.salesAcc;
+        this.audiCnt         = other.audiCnt;
+        this.audiInten       = other.audiInten;
+        this.audiChange      = other.audiChange;
+        this.audiAcc         = other.audiAcc;
+        this.scrnCnt         = other.scrnCnt;
+        this.showCnt         = other.showCnt;
+        this.salesAmt       = other.salesAmt;
+    }
 }

--- a/src/main/java/com/insidemovie/backend/api/movie/repository/DailyBoxOfficeRepository.java
+++ b/src/main/java/com/insidemovie/backend/api/movie/repository/DailyBoxOfficeRepository.java
@@ -5,8 +5,10 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import java.time.LocalDate;
+import java.util.Optional;
 
 public interface DailyBoxOfficeRepository extends JpaRepository<DailyBoxOfficeEntity, Long> {
     void deleteByTargetDate(LocalDate date);
     Page<DailyBoxOfficeEntity> findByTargetDate(LocalDate date, Pageable pageable);
+    Optional<DailyBoxOfficeEntity> findByTargetDateAndMovieCd(LocalDate targetDate, String movieCd);
 }

--- a/src/main/java/com/insidemovie/backend/api/movie/repository/DailyBoxOfficeRepository.java
+++ b/src/main/java/com/insidemovie/backend/api/movie/repository/DailyBoxOfficeRepository.java
@@ -11,4 +11,6 @@ public interface DailyBoxOfficeRepository extends JpaRepository<DailyBoxOfficeEn
     void deleteByTargetDate(LocalDate date);
     Page<DailyBoxOfficeEntity> findByTargetDate(LocalDate date, Pageable pageable);
     Optional<DailyBoxOfficeEntity> findByTargetDateAndMovieCd(LocalDate targetDate, String movieCd);
+
+    Optional<DailyBoxOfficeEntity> findByMovie_TmdbMovieIdAndTargetDate(Long tmdbMovieId, LocalDate date);
 }

--- a/src/main/java/com/insidemovie/backend/api/movie/repository/DailyBoxOfficeRepository.java
+++ b/src/main/java/com/insidemovie/backend/api/movie/repository/DailyBoxOfficeRepository.java
@@ -1,9 +1,12 @@
 package com.insidemovie.backend.api.movie.repository;
 
 import com.insidemovie.backend.api.movie.entity.boxoffice.DailyBoxOfficeEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import java.time.LocalDate;
 
 public interface DailyBoxOfficeRepository extends JpaRepository<DailyBoxOfficeEntity, Long> {
     void deleteByTargetDate(LocalDate date);
+    Page<DailyBoxOfficeEntity> findByTargetDate(LocalDate date, Pageable pageable);
 }

--- a/src/main/java/com/insidemovie/backend/api/movie/repository/MovieGenreRepository.java
+++ b/src/main/java/com/insidemovie/backend/api/movie/repository/MovieGenreRepository.java
@@ -23,4 +23,5 @@ public interface MovieGenreRepository extends JpaRepository<MovieGenre, Long> {
     List<MovieGenre> findByMovieId(Long movieId);
     Page<MovieGenre> findByGenreTypeIn(List<GenreType> genreType, Pageable pageable);
 
+    List<MovieGenre> findByMovie(Movie movie);
 }

--- a/src/main/java/com/insidemovie/backend/api/movie/repository/WeeklyBoxOfficeRepository.java
+++ b/src/main/java/com/insidemovie/backend/api/movie/repository/WeeklyBoxOfficeRepository.java
@@ -10,4 +10,6 @@ public interface WeeklyBoxOfficeRepository extends JpaRepository<WeeklyBoxOffice
     Page<WeeklyBoxOfficeEntity> findByYearWeekTime(String yearWeekTime, Pageable pageable);
     Optional<WeeklyBoxOfficeEntity> findFirstByOrderByYearWeekTimeDesc();
     Optional<WeeklyBoxOfficeEntity> findByYearWeekTimeAndMovieCd(String yearWeekTime, String movieCd);
+
+    Optional<WeeklyBoxOfficeEntity> findByMovie_TmdbMovieIdAndYearWeekTime(Long tmdbMovieId, String yearWeekTime);
 }

--- a/src/main/java/com/insidemovie/backend/api/movie/repository/WeeklyBoxOfficeRepository.java
+++ b/src/main/java/com/insidemovie/backend/api/movie/repository/WeeklyBoxOfficeRepository.java
@@ -7,8 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface WeeklyBoxOfficeRepository extends JpaRepository<WeeklyBoxOfficeEntity, Long> {
-    // 특정 연도주차 레코드를 모두 삭제
-    void deleteByYearWeekTime(String yearWeekTime);
     Page<WeeklyBoxOfficeEntity> findByYearWeekTime(String yearWeekTime, Pageable pageable);
     Optional<WeeklyBoxOfficeEntity> findFirstByOrderByYearWeekTimeDesc();
+    Optional<WeeklyBoxOfficeEntity> findByYearWeekTimeAndMovieCd(String yearWeekTime, String movieCd);
 }

--- a/src/main/java/com/insidemovie/backend/api/movie/repository/WeeklyBoxOfficeRepository.java
+++ b/src/main/java/com/insidemovie/backend/api/movie/repository/WeeklyBoxOfficeRepository.java
@@ -1,9 +1,14 @@
 package com.insidemovie.backend.api.movie.repository;
 
 import com.insidemovie.backend.api.movie.entity.boxoffice.WeeklyBoxOfficeEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
 
 public interface WeeklyBoxOfficeRepository extends JpaRepository<WeeklyBoxOfficeEntity, Long> {
     // 특정 연도주차 레코드를 모두 삭제
     void deleteByYearWeekTime(String yearWeekTime);
+    Page<WeeklyBoxOfficeEntity> findByYearWeekTime(String yearWeekTime, Pageable pageable);
+    Optional<WeeklyBoxOfficeEntity> findFirstByOrderByYearWeekTimeDesc();
 }

--- a/src/main/java/com/insidemovie/backend/api/movie/scheduler/DailyBoxOfficeScheduler.java
+++ b/src/main/java/com/insidemovie/backend/api/movie/scheduler/DailyBoxOfficeScheduler.java
@@ -32,6 +32,6 @@ public class DailyBoxOfficeScheduler {
             .itemPerPage(10)
             .build();
 
-        boxOfficeService.getDailyBoxOffice(req);
+        boxOfficeService.fetchAndStoreDailyBoxOffice(req);
     }
 }

--- a/src/main/java/com/insidemovie/backend/api/movie/scheduler/WeeklyBoxOfficeScheduler.java
+++ b/src/main/java/com/insidemovie/backend/api/movie/scheduler/WeeklyBoxOfficeScheduler.java
@@ -33,6 +33,6 @@ public class WeeklyBoxOfficeScheduler {
             .itemPerPage(10)
             .build();
 
-        boxOfficeService.getWeeklyBoxOffice(req);
+        boxOfficeService.fetchAndStoreWeeklyBoxOffice(req);
     }
 }

--- a/src/main/java/com/insidemovie/backend/api/movie/service/BoxOfficeService.java
+++ b/src/main/java/com/insidemovie/backend/api/movie/service/BoxOfficeService.java
@@ -106,7 +106,7 @@ public class BoxOfficeService {
         String showRange = targetDt + "~" + targetDt;
         return BoxOfficeListDTO.<DailyBoxOfficeResponseDTO>builder()
             .boxofficeType("일별")
-            .showRange(showRange)
+
             .items(items)
             .build();
     }
@@ -210,7 +210,6 @@ public class BoxOfficeService {
         // 6) 응답
         return BoxOfficeListDTO.<WeeklyBoxOfficeResponseDTO>builder()
             .boxofficeType("주간")
-            .showRange(yearWeek)
             .items(items)
             .build();
     }
@@ -285,7 +284,7 @@ public class BoxOfficeService {
 
         return BoxOfficeListDTO.<DailyBoxOfficeResponseDTO>builder()
             .boxofficeType("일별")
-            .showRange(targetDt + "~" + targetDt)
+            .targetDt(targetDt)
             .items(items)
             .build();
     }
@@ -297,7 +296,7 @@ public class BoxOfficeService {
     public BoxOfficeListDTO<WeeklyBoxOfficeResponseDTO> getSavedWeeklyBoxOffice(
             String targetDt, String weekGb, int itemPerPage
     ) {
-        // 1) 파라미터가 없으면 가장 최근 저장된 yearWeekTime 조회
+        // 파라미터가 없으면 가장 최근 저장된 yearWeekTime 조회
         String yearWeek = Optional.ofNullable(targetDt)
             .filter(dt -> !dt.isBlank())
             .map(dt -> {
@@ -317,7 +316,7 @@ public class BoxOfficeService {
                               ))
             );
 
-        // 2) 페이징 조회
+        // 페이징 조회
         Pageable pageReq = PageRequest.of(0, itemPerPage, Sort.by("movieRank"));
         Page<WeeklyBoxOfficeEntity> page = weeklyRepo.findByYearWeekTime(yearWeek, pageReq);
 
@@ -334,7 +333,7 @@ public class BoxOfficeService {
 
         return BoxOfficeListDTO.<WeeklyBoxOfficeResponseDTO>builder()
             .boxofficeType("주간")
-            .showRange(yearWeek)
+            .targetDt(yearWeek)
             .items(items)
             .build();
     }

--- a/src/main/java/com/insidemovie/backend/api/movie/service/BoxOfficeService.java
+++ b/src/main/java/com/insidemovie/backend/api/movie/service/BoxOfficeService.java
@@ -39,27 +39,61 @@ public class BoxOfficeService {
 
     private final MovieService movieService;
     @Value("${kobis.api.key}")         private String kobisApiKey;
-    @Value("${tmdb.api.base-url}")    private String tmdbBaseUrl;
-    @Value("${tmdb.api.key}")         private String tmdbApiKey;
-    @Value("${tmdb.api.language}")    private String tmdbLanguage;
 
     private final DailyBoxOfficeRepository dailyRepo;
     private final WeeklyBoxOfficeRepository weeklyRepo;
     private final MovieRepository movieRepo;
 
     private static final DateTimeFormatter FMT = DateTimeFormatter.ofPattern("yyyyMMdd");
+    private static final DateTimeFormatter ISO_FMT = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
     private static final String DAILY_URL_JSON =
         "http://kobis.or.kr/kobisopenapi/webservice/rest/boxoffice/searchDailyBoxOfficeList.json";
     private static final String WEEKLY_URL_JSON =
         "http://kobis.or.kr/kobisopenapi/webservice/rest/boxoffice/searchWeeklyBoxOfficeList.json";
-    private static final DateTimeFormatter ISO_FMT = DateTimeFormatter.ofPattern("yyyy-MM-dd");
 
     // 일간 박스오피스 조회 및 저장
     @Transactional
-    public BoxOfficeListDTO<DailyBoxOfficeResponseDTO> getDailyBoxOffice(BoxOfficeRequestDTO req) {
+    public void fetchAndStoreDailyBoxOffice(BoxOfficeRequestDTO req) {
         // 어제 날짜 계산
         LocalDate date = LocalDate.now().minusDays(1);
-        String targetDt = date.format(FMT);
+        log.info("[Service] DailyBoxOffice for yesterday {} (targetDt={})", date, date.format(FMT));
+
+        // 최신(어제) 데이터 API 호출
+        List<DailyBoxOfficeEntity> fetched = fetchDailyFromApi(date, req.getItemPerPage());
+
+        // 업서트 루프
+        for (DailyBoxOfficeEntity e : fetched) {
+            // targetDate + movieCd 로 기존 데이터 조회
+            Optional<DailyBoxOfficeEntity> opt = dailyRepo
+                .findByTargetDateAndMovieCd(date, e.getMovieCd());
+
+            DailyBoxOfficeEntity toSave;
+            if (opt.isPresent()) {
+                toSave = opt.get();
+                toSave.updateFrom(e);
+            } else {
+                toSave = e;
+            }
+
+            // TMDB 연동: 영화 제목+개봉연도로 TMDB ID 조회/저장
+            movieService.searchMovieByTitleAndYear(
+                toSave.getMovieName(),
+                LocalDate.parse(toSave.getOpenDate(), ISO_FMT).getYear()
+                )
+                .ifPresent(dto -> {
+                    Optional<Movie> existingMovie = movieRepo.findByTmdbMovieId(dto.getId());
+                    if (existingMovie.isEmpty()) {
+                        // DB에 없을 때만 TMDB API 호출 + 저장
+                        movieService.fetchAndSaveMovieById(dto.getId());
+                    }
+                    log.info("[연동완료] {} ({}) → TMDB ID={}",
+                        toSave.getMovieName(), toSave.getMovieCd(), dto.getId());
+                });
+
+            // 저장
+            dailyRepo.save(toSave);
+        }
 
         // 기존 데이터 삭제
         dailyRepo.deleteByTargetDate(date);
@@ -69,29 +103,29 @@ public class BoxOfficeService {
 
         // 저장·DTO 변환·예외 처리
         dailyRepo.saveAll(entities);
-        
+
         entities.forEach(e -> {
             movieService.searchMovieByTitleAndYear(
                     e.getMovieName(),
                     LocalDate.parse(e.getOpenDate(), ISO_FMT).getYear()
                 )
                 .ifPresent(dto -> {
-                    // ➌ TMDB 상세정보 먼저 저장
+                    // TMDB 상세정보 먼저 저장
                     movieService.fetchAndSaveMovieById(dto.getId());
 
-                    // ➍ 저장된 Movie 엔티티 조회
+                    // 저장된 Movie 엔티티 조회
                     Movie movie = movieRepo.findByTmdbMovieId(dto.getId())
                         .orElseThrow(() -> new IllegalStateException(
                             "Movie not found for TMDB ID=" + dto.getId()));
 
-                    // ➎ DailyBoxOfficeEntity 와 연관 설정
+                    // DailyBoxOfficeEntity 와 연관 설정
                     e.setMovie(movie);
 
                     log.info("[연동완료] {} ({}) → TMDB ID={}",
                         e.getMovieName(), e.getMovieCd(), dto.getId());
                 });
         });
-        
+
         List<DailyBoxOfficeResponseDTO> items = entities.stream()
             .map(DailyBoxOfficeResponseDTO::fromEntity)
             .collect(Collectors.toList());
@@ -103,12 +137,10 @@ public class BoxOfficeService {
             );
         }
 
-        String showRange = targetDt + "~" + targetDt;
-        return BoxOfficeListDTO.<DailyBoxOfficeResponseDTO>builder()
-            .boxofficeType("일별")
-
-            .items(items)
-            .build();
+        BoxOfficeListDTO.<DailyBoxOfficeResponseDTO>builder()
+                .boxofficeType("일별")
+                .items(items)
+                .build();
     }
 
     // 외부 API 호출하여 일간 엔티티 목록 생성
@@ -156,89 +188,79 @@ public class BoxOfficeService {
 
     // 주간 박스오피스 조회 및 저장
     @Transactional
-    public BoxOfficeListDTO<WeeklyBoxOfficeResponseDTO> getWeeklyBoxOffice(BoxOfficeRequestDTO req) {
-        // 1) 어제 대신 '지난주' 날짜 구하기
+    public void fetchAndStoreWeeklyBoxOffice(BoxOfficeRequestDTO req) {
+        // 1) 지난주 기준 날짜 & 연주차 계산
         LocalDate lastWeekDate = LocalDate.now().minusWeeks(1);
         String targetDt = lastWeekDate.format(FMT);
-
-        // 2) ISO 주차 기준으로 '년+주차' 문자열 생성 (예: 2025IW28)
         WeekFields wf = WeekFields.ISO;
-        int week = lastWeekDate.get(wf.weekOfWeekBasedYear());
+        int weekOfYear = lastWeekDate.get(wf.weekOfWeekBasedYear());
         int year = lastWeekDate.get(wf.weekBasedYear());
-        String yearWeek = String.format("%04dIW%02d", year, week);
+        String yearWeek = String.format("%04dIW%02d", year, weekOfYear);
 
         log.info("[Service] WeeklyBoxOffice for last week {} (yearWeek={})", targetDt, yearWeek);
 
-        // 3) 기존 DB 삭제
-        weeklyRepo.deleteByYearWeekTime(yearWeek);
-
-        // 4) API 호출 (지난주 targetDt, req.getWeekGb(), req.getItemPerPage(), yearWeek 사용)
-        List<WeeklyBoxOfficeEntity> entities =
+        // 2) KOFIC API 호출 (단 한 번)
+        List<WeeklyBoxOfficeEntity> fetched =
             fetchWeeklyFromApi(lastWeekDate, req.getWeekGb(), req.getItemPerPage(), yearWeek);
 
-        // 5) 저장·DTO 변환
-        weeklyRepo.saveAll(entities);
+        // 3) 업서트 루프
+        for (WeeklyBoxOfficeEntity e : fetched) {
+            // 3-1) 기존 데이터 조회
+            Optional<WeeklyBoxOfficeEntity> opt =
+                weeklyRepo.findByYearWeekTimeAndMovieCd(yearWeek, e.getMovieCd());
 
-        entities.forEach(e -> {
+            WeeklyBoxOfficeEntity toSave = opt
+                .map(existing -> {
+                    existing.updateFrom(e);
+                    return existing;
+                })
+                .orElse(e);
+
+            // 4) TMDB 연동: movieId가 없으면 한 번만 저장
             movieService.searchMovieByTitleAndYear(
-                    e.getMovieNm(),
-                    // ISO_FMT = DateTimeFormatter.ofPattern("yyyy-MM-dd")
-                    LocalDate.parse(e.getOpenDt(), ISO_FMT).getYear()
+                    toSave.getMovieNm(),
+                    LocalDate.parse(toSave.getOpenDt(), ISO_FMT).getYear()
                 )
                 .ifPresent(dto -> {
-                    movieService.fetchAndSaveMovieById(dto.getId());
-                    Movie movie = movieRepo.findByTmdbMovieId(dto.getId())
-                        .orElseThrow(() -> new IllegalStateException(
-                            "Movie not found for TMDB ID=" + dto.getId()));
-                    e.setMovie(movie);
+                    Optional<Movie> existingMovie = movieRepo.findByTmdbMovieId(dto.getId());
+                    if (existingMovie.isEmpty()) {
+                        movieService.fetchAndSaveMovieById(dto.getId());
+                    }
                     log.info("[연동완료] {} ({}) → TMDB ID={}",
-                        e.getMovieNm(), e.getMovieCd(), dto.getId());
+                        toSave.getMovieNm(), toSave.getMovieCd(), dto.getId());
                 });
-            });
 
-        List<WeeklyBoxOfficeResponseDTO> items = entities.stream()
-            .map(WeeklyBoxOfficeResponseDTO::fromEntity)
-            .collect(Collectors.toList());
-
-        if (items.isEmpty()) {
-            throw new BaseException(
-                ErrorStatus.NOT_FOUND_WEEKLY_BOXOFFICE.getHttpStatus(),
-                ErrorStatus.NOT_FOUND_WEEKLY_BOXOFFICE.getMessage()
-            );
+            // 5) 저장 (insert 또는 update)
+            weeklyRepo.save(toSave);
         }
 
-        // 6) 응답
-        return BoxOfficeListDTO.<WeeklyBoxOfficeResponseDTO>builder()
-            .boxofficeType("주간")
-            .items(items)
-            .build();
+        log.info("[Service] Completed upsert of {} weekly box office records", fetched.size());
     }
 
     // 외부 API 호출하여 주간 엔티티 목록 생성
     private List<WeeklyBoxOfficeEntity> fetchWeeklyFromApi(
-            LocalDate date,
-            String weekGb,
-            int itemPerPage,
-            String yearWeek
+        LocalDate date,
+        String weekGb,
+        int itemPerPage,
+        String yearWeek
     ) {
         String targetDt = date.format(FMT);
-        RestTemplate rest = new RestTemplate();
         String uri = UriComponentsBuilder
             .fromHttpUrl(WEEKLY_URL_JSON)
             .queryParam("key", kobisApiKey)
-            .queryParam("targetDt", targetDt)    // 지난 주 기준 날짜
-            .queryParam("weekGb", weekGb)        // 요청으로 넘어온 대로 사용
+            .queryParam("targetDt", targetDt)
+            .queryParam("weekGb", weekGb)
             .queryParam("itemPerPage", itemPerPage)
             .toUriString();
 
-        JsonNode listNode = rest.getForObject(uri, JsonNode.class)
+        JsonNode listNode = new RestTemplate().getForObject(uri, JsonNode.class)
             .path("boxOfficeResult")
             .path("weeklyBoxOfficeList");
 
         return StreamSupport.stream(listNode.spliterator(), false)
             .limit(itemPerPage)
             .map(node -> WeeklyBoxOfficeEntity.builder()
-                .yearWeekTime(yearWeek)                // DB에 저장할 연주차
+                .yearWeekTime(yearWeek)
                 .rnum(node.path("rnum").asText())
                 .movieRank(node.path("rank").asText())
                 .rankInten(node.path("rankInten").asText())

--- a/src/main/java/com/insidemovie/backend/common/config/security/SecurityConfig.java
+++ b/src/main/java/com/insidemovie/backend/common/config/security/SecurityConfig.java
@@ -91,7 +91,8 @@ public class SecurityConfig {
                 .requestMatchers(
                         HttpMethod.GET,
                         "/api/v1/movies/*/reviews",
-                        "/api/v1/movies/**"
+                        "/api/v1/movies/**",
+                        "/api/v1/boxoffice/**"
                 ).permitAll()
 
                 // Public POST

--- a/src/main/java/com/insidemovie/backend/common/response/ErrorStatus.java
+++ b/src/main/java/com/insidemovie/backend/common/response/ErrorStatus.java
@@ -33,6 +33,8 @@ public enum ErrorStatus {
     NOT_FOUND_WEEKLY_BOXOFFICE(HttpStatus.NOT_FOUND, "주간 박스오피스 데이터를 찾을 수 없습니다."),
     NOT_FOUND_GENRE_EXCEPTION(HttpStatus.NOT_FOUND, "존재하지 않는 장르 입니다."),
     NOT_FOUND_REPORT_EXCEPTION(HttpStatus.NOT_FOUND, "존재하지 않는 신고입니다."),
+    NOT_FOUND_DAILY_MOIVE(HttpStatus.NOT_FOUND, "일간 박스오피스 영화의 상세 정보를 찾을 수 없습니다."),
+    NOT_FOUND_WEEKLY_MOIVE(HttpStatus.NOT_FOUND, "주간 박스오피스 영화의 상세 정보를 찾을 수 없습니다."),
 
     /** 500 SERVER_ERROR */
     FAIL_UPLOAD_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR,"파일 업로드 실패하였습니다."),

--- a/src/main/java/com/insidemovie/backend/common/response/SuccessStatus.java
+++ b/src/main/java/com/insidemovie/backend/common/response/SuccessStatus.java
@@ -45,6 +45,8 @@ public enum SuccessStatus {
     UPDATE_PROFILE_IMAGE_SUCCESS(HttpStatus.OK, "프로필 이미지 변경 성공"),
     CHECK_NICKNAME_SUCCESS(HttpStatus.OK, "닉네임 중복 여부 확인 성공"),
     SEND_POPULAR_MOVIES_SUCCESS(HttpStatus.OK, "인기 영화 조회 성공"),
+    SEND_BOXOFFICE_MOVIE_DETAIL_SUCCESS(HttpStatus.OK, "박스오피스의 상세정보 조회 성공"),
+
 
 
 


### PR DESCRIPTION
## 📣 Related Issue
- close #118 

## 📝 Summary
- 박스오피스 스케줄러 서비스 로직 개선  
  - Movie DB에 이미 저장된 영화가 중복 저장되어 발생하던 오류 수정  
  - 중복 저장 방지 검증 로직 추가  
- 일간·주간 박스오피스 영화 상세 조회 API 기능 추가
- 스웨거 참고 바랍니다.