### PR TITLE
[REFAC] 감정 상태 neutral -> disgust로 변경 및 데이터 마이그레이션 작업 수행

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,11 @@ dependencies {
 	// Spring Batch
 	implementation 'org.springframework.boot:spring-boot-starter-batch'
 
+	// 데이터 마이그레이션 툴
+	implementation 'org.flywaydb:flyway-core'
+	implementation "org.flywaydb:flyway-mysql:11.7.2"
+
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/insidemovie/backend/api/constant/EmotionType.java
+++ b/src/main/java/com/insidemovie/backend/api/constant/EmotionType.java
@@ -5,5 +5,5 @@ public enum EmotionType {
     SADNESS,
     ANGER,
     FEAR,
-    NEUTRAL,
+    DISGUST,
 }

--- a/src/main/java/com/insidemovie/backend/api/member/dto/emotion/EmotionAvgDTO.java
+++ b/src/main/java/com/insidemovie/backend/api/member/dto/emotion/EmotionAvgDTO.java
@@ -21,22 +21,22 @@ public class EmotionAvgDTO {
     @Builder.Default
     private Double fear    = 0.0;
     @Builder.Default
-    private Double neutral = 0.0;
+    private Double disgust = 0.0;
 
     @Builder.Default
-    private EmotionType repEmotionType = EmotionType.NEUTRAL;
+    private EmotionType repEmotionType = EmotionType.DISGUST;
 
     public EmotionAvgDTO(Double joy,
                          Double sadness,
                          Double anger,
                          Double fear,
-                         Double neutral) {
+                         Double disgust) {
         this.joy             = joy != null ? joy : 0.0;
         this.sadness         = sadness != null ? sadness : 0.0;
         this.anger           = anger != null ? anger : 0.0;
         this.fear            = fear != null ? fear : 0.0;
-        this.neutral         = neutral != null ? neutral : 0.0;
-        this.repEmotionType  = EmotionType.NEUTRAL;
+        this.disgust = disgust != null ? disgust : 0.0;
+        this.repEmotionType  = EmotionType.DISGUST;
     }
 
     public void setRepEmotionType(EmotionType repEmotionType) {

--- a/src/main/java/com/insidemovie/backend/api/member/dto/emotion/MemberEmotionSummaryRequestDTO.java
+++ b/src/main/java/com/insidemovie/backend/api/member/dto/emotion/MemberEmotionSummaryRequestDTO.java
@@ -22,5 +22,5 @@ public class MemberEmotionSummaryRequestDTO {
     private Float anger;
 
     @NotNull @Min(0) @Max(1)
-    private Float neutral;
+    private Float disgust;
 }

--- a/src/main/java/com/insidemovie/backend/api/member/dto/emotion/MemberEmotionSummaryResponseDTO.java
+++ b/src/main/java/com/insidemovie/backend/api/member/dto/emotion/MemberEmotionSummaryResponseDTO.java
@@ -13,7 +13,7 @@ public class MemberEmotionSummaryResponseDTO {
     private Double sadness;
     private Double anger;
     private Double fear;
-    private Double neutral;
+    private Double disgust;
     private EmotionType repEmotion;
 
     /**
@@ -26,7 +26,7 @@ public class MemberEmotionSummaryResponseDTO {
             .sadness(e.getSadness().doubleValue())
             .anger(e.getAnger().doubleValue())
             .fear(e.getFear().doubleValue())
-            .neutral(e.getNeutral().doubleValue())
+            .disgust(e.getDisgust().doubleValue())
             .repEmotion(e.getRepEmotionType())
             .build();
     }

--- a/src/main/java/com/insidemovie/backend/api/member/entity/MemberEmotionSummary.java
+++ b/src/main/java/com/insidemovie/backend/api/member/entity/MemberEmotionSummary.java
@@ -28,29 +28,10 @@ public class MemberEmotionSummary {
     private Float sadness;
     private Float fear;
     private Float anger;
-    private Float neutral;
+    private Float disgust;
 
     @Enumerated(EnumType.STRING)
     private EmotionType repEmotionType; // 대표 감정
-
-//    @Column(nullable = false)
-//    private Float joy = 0.0f;
-//
-//    @Column(nullable = false)
-//    private Float sadness = 0.0f;
-//
-//    @Column(nullable = false)
-//    private Float anger = 0.0f;
-//
-//    @Column(nullable = false)
-//    private Float fear = 0.0f;
-//
-//    @Column(nullable = false)
-//    private Float neutral = 0.0f;
-//
-//    @Enumerated(EnumType.STRING)
-//    @Column(nullable = false)
-//    private EmotionType repEmotionType = EmotionType.NEUTRAL;
 
     // 평균 감정 정보를 DTO로부터 갱신
     public void updateFromDTO(EmotionAvgDTO dto) {
@@ -58,7 +39,7 @@ public class MemberEmotionSummary {
         this.sadness        = dto.getSadness().floatValue();
         this.anger          = dto.getAnger().floatValue();
         this.fear           = dto.getFear().floatValue();
-        this.neutral        = dto.getNeutral().floatValue();
+        this.disgust        = dto.getDisgust().floatValue();
         this.repEmotionType = dto.getRepEmotionType();
     }
 }

--- a/src/main/java/com/insidemovie/backend/api/member/service/MemberService.java
+++ b/src/main/java/com/insidemovie/backend/api/member/service/MemberService.java
@@ -306,8 +306,8 @@ public class MemberService {
         EmotionAvgDTO avg = emotionRepository
                 .findAverageEmotionsByMemberId(memberId)
                 .orElseGet(() -> EmotionAvgDTO.builder()
-                        .joy(0.0).sadness(0.0).anger(0.0).fear(0.0).neutral(0.0)
-                        .repEmotionType(EmotionType.NEUTRAL)
+                        .joy(0.0).sadness(0.0).anger(0.0).fear(0.0).disgust(0.0)
+                        .repEmotionType(EmotionType.DISGUST)
                         .build()
                 );
 
@@ -338,14 +338,14 @@ public class MemberService {
                 EmotionType.SADNESS, dto.getSadness(),
                 EmotionType.ANGER,   dto.getAnger(),
                 EmotionType.FEAR,    dto.getFear(),
-                EmotionType.NEUTRAL, dto.getNeutral()
+                EmotionType.DISGUST, dto.getDisgust()
         );
 
         // 최댓값 감정 리턴
         return scores.entrySet().stream()
                 .max(Map.Entry.comparingByValue())
                 .map(Map.Entry::getKey)
-                .orElse(EmotionType.NEUTRAL);
+                .orElse(EmotionType.DISGUST);
     }
 
     // 초기 사용자 감정 상태 저장
@@ -366,7 +366,7 @@ public class MemberService {
         // 대표 감정 계산 (가장 점수가 높은 타입)
         EmotionType rep = findMaxEmotion(
             dto.getJoy(), dto.getSadness(), dto.getFear(),
-            dto.getAnger(), dto.getNeutral()
+            dto.getAnger(), dto.getDisgust()
             );
 
         // 엔티티 생성 및 저장
@@ -376,7 +376,7 @@ public class MemberService {
             .sadness(dto.getSadness())
             .fear(dto.getFear())
             .anger(dto.getAnger())
-            .neutral(dto.getNeutral())
+            .disgust(dto.getDisgust())
             .repEmotionType(rep)
             .build();
 
@@ -386,14 +386,14 @@ public class MemberService {
 
     public static EmotionType findMaxEmotion(
                 Float joy, Float sadness, Float fear,
-                Float anger, Float neutral
+                Float anger, Float disgust
         ) {
             return Map.<EmotionType, Float>of(
                 EmotionType.JOY,    joy,
                 EmotionType.SADNESS,sadness,
                 EmotionType.FEAR,   fear,
                 EmotionType.ANGER,  anger,
-                EmotionType.NEUTRAL,neutral
+                EmotionType.DISGUST,disgust
             ).entrySet().stream()
              .max(Map.Entry.comparingByValue())
              .orElseThrow()  // 혹은 기본값 설정
@@ -416,7 +416,7 @@ public class MemberService {
         double avgSadness = avg(summary.getSadness(), dto.getSadness());
         double avgAnger   = avg(summary.getAnger(),   dto.getAnger());
         double avgFear    = avg(summary.getFear(),    dto.getFear());
-        double avgNeutral = avg(summary.getNeutral(), dto.getNeutral());
+        double avgDisgust = avg(summary.getDisgust(), dto.getDisgust());
 
         // 대표 감정 타입은 평균 값 중 최대인 것으로 판단
         EmotionType repType = Stream.of(
@@ -424,18 +424,18 @@ public class MemberService {
                 new AbstractMap.SimpleEntry<>(EmotionType.SADNESS, avgSadness),
                 new AbstractMap.SimpleEntry<>(EmotionType.ANGER,   avgAnger),
                 new AbstractMap.SimpleEntry<>(EmotionType.FEAR,    avgFear),
-                new AbstractMap.SimpleEntry<>(EmotionType.NEUTRAL, avgNeutral)
+                new AbstractMap.SimpleEntry<>(EmotionType.DISGUST, avgDisgust)
             )
             .max(Comparator.comparingDouble(Map.Entry::getValue))
             .map(Map.Entry::getKey)
-            .orElse(EmotionType.NEUTRAL);
+            .orElse(EmotionType.DISGUST);
 
         EmotionAvgDTO avgDto = EmotionAvgDTO.builder()
             .joy(avgJoy)
             .sadness(avgSadness)
             .anger(avgAnger)
             .fear(avgFear)
-            .neutral(avgNeutral)
+            .disgust(avgDisgust)
             .repEmotionType(repType)
             .build();
 

--- a/src/main/java/com/insidemovie/backend/api/movie/dto/emotion/MovieEmotionSummaryResponseDTO.java
+++ b/src/main/java/com/insidemovie/backend/api/movie/dto/emotion/MovieEmotionSummaryResponseDTO.java
@@ -8,6 +8,6 @@ public class MovieEmotionSummaryResponseDTO {
     private Float anger;
     private Float sadness;
     private Float fear;
-    private Float neutral;
+    private Float disgust;
     private String dominantEmotion;
 }

--- a/src/main/java/com/insidemovie/backend/api/movie/entity/MovieEmotionSummary.java
+++ b/src/main/java/com/insidemovie/backend/api/movie/entity/MovieEmotionSummary.java
@@ -25,7 +25,7 @@ public class MovieEmotionSummary {
     private Float sadness;
     private Float fear;
     private Float anger;
-    private Float neutral;
+    private Float disgust;
 
     @Enumerated(EnumType.STRING)
     private EmotionType dominantEmotion; // 대표 감정
@@ -35,7 +35,7 @@ public class MovieEmotionSummary {
         this.sadness = dto.getSadness().floatValue();
         this.anger = dto.getAnger().floatValue();
         this.fear = dto.getFear().floatValue();
-        this.neutral = dto.getNeutral().floatValue();
+        this.disgust = dto.getDisgust().floatValue();
         this.dominantEmotion = dto.getRepEmotionType();
     }
 }

--- a/src/main/java/com/insidemovie/backend/api/movie/service/MovieService.java
+++ b/src/main/java/com/insidemovie/backend/api/movie/service/MovieService.java
@@ -335,8 +335,8 @@ public class MovieService {
                 dto.getSadness() == 0.0 &&
                 dto.getAnger() == 0.0 &&
                 dto.getFear() == 0.0 &&
-                dto.getNeutral() == 0.0) {
-            return EmotionType.NEUTRAL;
+                dto.getDisgust() == 0.0) {
+            return EmotionType.DISGUST;
         }
 
         Map<EmotionType, Double> scores = Map.of(

--- a/src/main/java/com/insidemovie/backend/api/movie/service/MovieService.java
+++ b/src/main/java/com/insidemovie/backend/api/movie/service/MovieService.java
@@ -303,8 +303,8 @@ public class MovieService {
         // 감정 평균 조회
         EmotionAvgDTO avg = emotionRepository.findAverageEmotionsByMovieId(movieId)
                 .orElseGet(() -> EmotionAvgDTO.builder()
-                        .joy(0.0).sadness(0.0).anger(0.0).fear(0.0).neutral(0.0)
-                        .repEmotionType(EmotionType.NEUTRAL)
+                        .joy(0.0).sadness(0.0).anger(0.0).fear(0.0).disgust(0.0)
+                        .repEmotionType(EmotionType.DISGUST)
                         .build());
 
         // 대표 감정 계산
@@ -334,13 +334,13 @@ public class MovieService {
                 EmotionType.SADNESS, dto.getSadness(),
                 EmotionType.ANGER, dto.getAnger(),
                 EmotionType.FEAR, dto.getFear(),
-                EmotionType.NEUTRAL, dto.getNeutral()
+                EmotionType.DISGUST, dto.getDisgust()
         );
 
         return scores.entrySet().stream()
                 .max(Map.Entry.comparingByValue())
                 .map(Map.Entry::getKey)
-                .orElse(EmotionType.NEUTRAL);
+                .orElse(EmotionType.DISGUST);
     }
 
     /**
@@ -355,7 +355,7 @@ public class MovieService {
                 dto.setSadness(summary.getSadness());
                 dto.setFear(summary.getFear());
                 dto.setAnger(summary.getAnger());
-                dto.setNeutral(summary.getNeutral());
+                dto.setDisgust(summary.getDisgust());
                 dto.setDominantEmotion(summary.getDominantEmotion().name());
                 return dto;
             })
@@ -366,7 +366,7 @@ public class MovieService {
                 dto.setSadness(0f);
                 dto.setFear(0f);
                 dto.setAnger(0f);
-                dto.setNeutral(0f);
+                dto.setDisgust(0f);
                 dto.setDominantEmotion("NONE");
                 return dto;
             });

--- a/src/main/java/com/insidemovie/backend/api/recommend/dto/EmotionRequestDTO.java
+++ b/src/main/java/com/insidemovie/backend/api/recommend/dto/EmotionRequestDTO.java
@@ -8,6 +8,6 @@ public class EmotionRequestDTO {
     private double joy;
     private double anger;
     private double fear;
-    private double neutral;
+    private double disgust;
     private double sadness;
 }

--- a/src/main/java/com/insidemovie/backend/api/recommend/service/EmotionRecommendationService.java
+++ b/src/main/java/com/insidemovie/backend/api/recommend/service/EmotionRecommendationService.java
@@ -27,7 +27,7 @@ public class EmotionRecommendationService {
                 "joy", userEmotion.getJoy(),
                 "anger", userEmotion.getAnger(),
                 "fear", userEmotion.getFear(),
-                "neutral", userEmotion.getNeutral(),
+                "disgust", userEmotion.getDisgust(),
                 "sadness", userEmotion.getSadness()
         ));
 
@@ -44,7 +44,7 @@ public class EmotionRecommendationService {
                             "sadness", movie.getSadness().doubleValue(),
                             "anger", movie.getAnger().doubleValue(),
                             "fear", movie.getFear().doubleValue(),
-                            "neutral", movie.getNeutral().doubleValue()
+                            "disgust", movie.getDisgust().doubleValue()
                     ));
 
                     // 유사도 계산
@@ -56,7 +56,7 @@ public class EmotionRecommendationService {
                         case SADNESS -> movie.getSadness().doubleValue();
                         case ANGER -> movie.getAnger().doubleValue();
                         case FEAR -> movie.getFear().doubleValue();
-                        case NEUTRAL -> movie.getNeutral().doubleValue();
+                        case DISGUST -> movie.getDisgust().doubleValue();
                     };
 
                     return new MovieRecommendationDTO(

--- a/src/main/java/com/insidemovie/backend/api/review/dto/EmotionDTO.java
+++ b/src/main/java/com/insidemovie/backend/api/review/dto/EmotionDTO.java
@@ -10,7 +10,7 @@ public class EmotionDTO {
     private Double anger;
     private Double fear;
     private Double joy;
-    private Double neutral;
+    private Double disgust;
     private Double sadness;
     private String repEmotion;
 }

--- a/src/main/java/com/insidemovie/backend/api/review/entity/Emotion.java
+++ b/src/main/java/com/insidemovie/backend/api/review/entity/Emotion.java
@@ -23,7 +23,7 @@ public class Emotion {
     private double sadness;
     private double anger;
     private double fear;
-    private double neutral;
+    private double disgust;
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "review_id", nullable = false, unique = true)

--- a/src/main/java/com/insidemovie/backend/api/review/repository/EmotionRepository.java
+++ b/src/main/java/com/insidemovie/backend/api/review/repository/EmotionRepository.java
@@ -18,7 +18,7 @@ public interface EmotionRepository extends JpaRepository<Emotion, Long> {
             COALESCE(AVG(e.sadness), 0.0),
             COALESCE(AVG(e.anger), 0.0),
             COALESCE(AVG(e.fear), 0.0),
-            COALESCE(AVG(e.neutral), 0.0)
+            COALESCE(AVG(e.disgust), 0.0)
         )
         FROM Emotion e
         WHERE e.review.member.id = :memberId
@@ -31,7 +31,7 @@ public interface EmotionRepository extends JpaRepository<Emotion, Long> {
             COALESCE(AVG(e.sadness), 0.0),
             COALESCE(AVG(e.anger), 0.0),
             COALESCE(AVG(e.fear), 0.0),
-            COALESCE(AVG(e.neutral), 0.0)
+            COALESCE(AVG(e.disgust), 0.0)
         )
         FROM Emotion e
         WHERE e.review.movie.id = :movieId

--- a/src/main/java/com/insidemovie/backend/api/review/service/ReviewService.java
+++ b/src/main/java/com/insidemovie/backend/api/review/service/ReviewService.java
@@ -25,7 +25,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -90,7 +89,7 @@ public class ReviewService {
                     .anger(probabilities.get("anger"))
                     .fear(probabilities.get("fear"))
                     .joy(probabilities.get("joy"))
-                    .neutral(probabilities.get("neutral"))
+                    .disgust(probabilities.get("disgust"))
                     .sadness(probabilities.get("sadness"))
                     .review(savedReview)
                     .build();
@@ -266,18 +265,18 @@ public class ReviewService {
                             "anger", e.getAnger(),
                             "fear", e.getFear(),
                             "joy", e.getJoy(),
-                            "neutral", e.getNeutral(),
+                            "disgust", e.getDisgust(),
                             "sadness", e.getSadness()
                     );
                     String rep = probs.entrySet().stream()
                             .max(Map.Entry.comparingByValue())
                             .map(Map.Entry::getKey)
-                            .orElse("neutral");
+                            .orElse("disgust");
                     return EmotionDTO.builder()
                             .anger(probs.get("anger"))
                             .fear(probs.get("fear"))
                             .joy(probs.get("joy"))
-                            .neutral(probs.get("neutral"))
+                            .disgust(probs.get("disgust"))
                             .sadness(probs.get("sadness"))
                             .repEmotion(rep)
                             .build();

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -20,5 +20,4 @@ spring:
   jpa:
     show-sql: true
     hibernate:
-      ddl-auto: update # 개발 환경: update
-
+      ddl-auto: validate # 개발 환경: update

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -11,7 +11,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: validate
     show-sql: true
     database-platform: org.hibernate.dialect.MySQL8Dialect
     properties:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,13 @@
 spring:
   profiles:
     active: local
+
+  flyway:
+    enabled: true
+    location: classpath:db/migration
+    baseline-on-migrate: true        # 기존 스키마를 베이스라인으로 설정
+    baseline-version: 1              # 이미 존재하는 스키마를 V1으로 간주
+
   config:
     import:
       - classpath:application-key.yml

--- a/src/main/resources/db/migration/V2__rename_neutral_to_disgust.sql
+++ b/src/main/resources/db/migration/V2__rename_neutral_to_disgust.sql
@@ -1,0 +1,3 @@
+UPDATE emotion
+SET disgust = COALESCE(disgust,0) + COALESCE(neutral,0);
+ALTER TABLE emotion DROP COLUMN neutral;


### PR DESCRIPTION
# ❗️주의: 바로 MERGE 하지 말아주세요.
## 📣 Related Issue

* Closes #141

## 📝 Summary

1. **감정 상태 컬럼명 변경**

   * 모델 출력 변경(neutral → disgust) 반영
2. **데이터 마이그레이션**

   * Flyway 기반 마이그레이션 스크립트(`V2__rename_neutral_to_disgust.sql`) 추가

     ```sql
     UPDATE emotion
       SET disgust = COALESCE(disgust, 0) + COALESCE(neutral, 0);
     ALTER TABLE emotion
       DROP COLUMN neutral;
     ```
3. **엔티티 및 레포지토리 수정**

   * `Emotion` 엔티티, 관련 JPA 리포지토리, DTO, API 스펙 등 일괄 리팩토링

## 🔍 Verification & Testing

* **로컬 실행**

  1. `./gradlew clean build`: `Gradle` 클린 빌드
  2. 애플리케이션 기동 시 Flyway가 자동으로 마이그레이션을 수행하는지 확인
* **컬럼 잔존 여부 확인**
  만약 `neutral` 컬럼이 남아있다면:

  ```sql
  SHOW COLUMNS FROM emotion LIKE 'neutral';
  ```

  * 남아 있다면 수동으로 삭제 후 재실행

## 🚀 Deployment Notes

* **dev 브랜치 머지 전 테스트 요청**

  * 먼저 `refac/#141` 브랜치에서 충분한 검증을 부탁드립니다.
* **배포 담당자(@et007693)**

  * 운영 환경에서도 Flyway 마이그레이션이 정상 동작하는지 최종 확인 필요
* **프론트엔드 협업(@Sangyoon98)**

  * 감정 상태(disgust) 변경에 따른 UI·캐릭터 표시 로직 수정 논의 및 리팩토링 필요

## 🙏 Review Points

1. 마이그레이션 스크립트 로직(값 합산 → 컬럼 삭제) 적절성
2. 엔티티·API 스펙 변경이 누락된 부분 없는지
3. CI/CD 파이프라인에서 Flyway 자동 마이그레이션이 정상 수행되는지
