### PR TITLE
[FIX] 박스오피스 에러 해결

### DIFF
--- a/src/main/java/com/insidemovie/backend/api/movie/entity/boxoffice/DailyBoxOfficeEntity.java
+++ b/src/main/java/com/insidemovie/backend/api/movie/entity/boxoffice/DailyBoxOfficeEntity.java
@@ -7,58 +7,82 @@ import java.time.LocalDate;
 
 
 @Entity
-@Table(name = "daily_box_office")
-@Getter
-@Setter
-@NoArgsConstructor
-@AllArgsConstructor
-@Builder
+@Table(
+    name = "daily_box_office",
+    uniqueConstraints = {
+        @UniqueConstraint(
+            name = "uk_daily_target_movie",
+            columnNames = {"target_date", "movie_cd"}
+        )
+    },
+    indexes = {
+        @Index(name = "idx_daily_target_rank", columnList = "target_date, movie_rank"),
+        @Index(name = "idx_daily_tmdb", columnList = "tmdb_id")
+    }
+)
+@Getter @Setter
+@NoArgsConstructor @AllArgsConstructor @Builder
 public class DailyBoxOfficeEntity {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    // TMDB 영화 (nullable: 아직 매핑 전일 수 있음)
     @ManyToOne(fetch = FetchType.LAZY, optional = true)
-    @JoinColumn(name = "tmdb_id", referencedColumnName = "tmdb_id")
+    @JoinColumn(name = "tmdb_id", referencedColumnName = "tmdb_id",
+                foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
     private Movie movie;
 
-    private LocalDate targetDate;       // 조회 일자
-    private String rnum;                // 순번
-    private String movieRank;           // 해당 일자 박스오피스 순위
-    private String rankInten;           // 전일 대비 순위 증감분
-    private String rankOldAndNew;       // 랭킹 신규 진입 여부(OLD or NEW)
-    private String movieCd;             // 영화 대표 코드
-    private String movieName;           // 영화 제목(국문)
-    private String openDate;            // 개봉일
-    private String salesShare;          // 매출 총액 대비 매출 비율
-    private String salesInten;          // 전일 대비 매출액 증감분
-    private String salesChange;         // 전일 대비 매출액 증감 비율
-    private String salesAcc;            // 누적 매출액
-    private String salesAmt;            // 매출액
-    private String audiCnt;             // 해당일 관객수
-    private String audiInten;           // 전일 대비 관객수 증감분
-    private String audiChange;          // 전일 대비 관객수 증감 비율
-    private String audiAcc;             // 누적 관객수
-    private String scrnCnt;             // 해당일 상영한 스크린 수
-    private String showCnt;             // 해당일 상영된 횟수
+    @Column(name = "target_date", nullable = false)
+    private LocalDate targetDate;
 
+    private String rnum;
+    @Column(name = "movie_rank")
+    private String movieRank;
+    private String rankInten;
+    private String rankOldAndNew;
+
+    @Column(name = "movie_cd", nullable = false)
+    private String movieCd;
+    @Column(name = "movie_name")
+    private String movieName;
+
+    @Column(name = "open_date")
+    private String openDate;
+
+    private String salesShare;
+    private String salesInten;
+    private String salesChange;
+    private String salesAcc;
+    private String salesAmt;
+
+    private String audiCnt;
+    private String audiInten;
+    private String audiChange;
+    private String audiAcc;
+
+    private String scrnCnt;
+    private String showCnt;
+
+    /** 기존 행을 새 API 데이터로 갱신 (변하지 않는 key 컬럼 제외) */
     public void updateFrom(DailyBoxOfficeEntity other) {
-        this.rnum            = other.rnum;
-        this.movieRank       = other.movieRank;
-        this.rankInten       = other.rankInten;
-        this.rankOldAndNew   = other.rankOldAndNew;
-        this.openDate        = other.openDate;
-        this.salesShare      = other.salesShare;
-        this.salesInten      = other.salesInten;
-        this.salesChange     = other.salesChange;
-        this.salesAcc        = other.salesAcc;
-        this.audiCnt         = other.audiCnt;
-        this.audiInten       = other.audiInten;
-        this.audiChange      = other.audiChange;
-        this.audiAcc         = other.audiAcc;
-        this.scrnCnt         = other.scrnCnt;
-        this.showCnt         = other.showCnt;
-        this.salesAmt        = other.salesAmt;
-        this.salesShare      = other.salesShare;
+        this.rnum          = other.rnum;
+        this.movieRank     = other.movieRank;
+        this.rankInten     = other.rankInten;
+        this.rankOldAndNew = other.rankOldAndNew;
+        this.openDate      = other.openDate;
+        this.salesShare    = other.salesShare;
+        this.salesInten    = other.salesInten;
+        this.salesChange   = other.salesChange;
+        this.salesAcc      = other.salesAcc;
+        this.salesAmt      = other.salesAmt;
+        this.audiCnt       = other.audiCnt;
+        this.audiInten     = other.audiInten;
+        this.audiChange    = other.audiChange;
+        this.audiAcc       = other.audiAcc;
+        this.scrnCnt       = other.scrnCnt;
+        this.showCnt       = other.showCnt;
+        // movieCd, movieName, targetDate 는 식별/표시 기본 속성 → 필요 시 유지
     }
 }

--- a/src/main/java/com/insidemovie/backend/api/movie/entity/boxoffice/WeeklyBoxOfficeEntity.java
+++ b/src/main/java/com/insidemovie/backend/api/movie/entity/boxoffice/WeeklyBoxOfficeEntity.java
@@ -4,59 +4,79 @@ import com.insidemovie.backend.api.movie.entity.Movie;
 import jakarta.persistence.*;
 import lombok.*;
 
-@Getter
-@Setter
-@NoArgsConstructor
-@AllArgsConstructor
-@Builder
 @Entity
-@Table(name = "weekly_box_office")
+@Table(
+    name = "weekly_box_office",
+    uniqueConstraints = {
+        @UniqueConstraint(
+            name = "uk_weekly_yearweek_movie",
+            columnNames = {"year_week_time", "movie_cd"}
+        )
+    },
+    indexes = {
+        @Index(name = "idx_weekly_yearweek_rank", columnList = "year_week_time, movie_rank"),
+        @Index(name = "idx_weekly_tmdb", columnList = "tmdb_id")
+    }
+)
+@Getter @Setter
+@NoArgsConstructor @AllArgsConstructor @Builder
 public class WeeklyBoxOfficeEntity {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = true)
-    @JoinColumn(name = "tmdb_id", referencedColumnName = "tmdb_id")
+    @JoinColumn(name = "tmdb_id", referencedColumnName = "tmdb_id",
+                foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
     private Movie movie;
 
-    @Column(name = "year_week_time")
-    private String yearWeekTime;    // 연도+주차 (YYYYIWww)
-    private String rnum;            // 순번
-    private String movieRank;            // 순위
-    private String rankInten;       // 순위 증감
-    private String rankOldAndNew;   // 신규 진입 여부
-    private String movieCd;         // 영화 코드
-    private String movieNm;         // 영화 이름
-    private String openDt;          // 개봉일
-    private String salesAmt;        // 매출액
-    private String salesShare;      // 매출 비율
-    private String salesInten;      // 매출 증감분
-    private String salesChange;     // 매출 증감 비율
-    private String salesAcc;        // 누적 매출액
-    private String audiCnt;         // 관객 수
-    private String audiInten;       // 관객 증감분
-    private String audiChange;      // 관객 증감 비율
-    private String audiAcc;         // 누적 관객수
-    private String scrnCnt;         // 상영 스크린 수
-    private String showCnt;         // 상영 횟수
+    @Column(name = "year_week_time", nullable = false)
+    private String yearWeekTime;
+
+    private String rnum;
+    @Column(name = "movie_rank")
+    private String movieRank;
+    private String rankInten;
+    private String rankOldAndNew;
+
+    @Column(name = "movie_cd", nullable = false)
+    private String movieCd;
+    @Column(name = "movie_nm")
+    private String movieNm;
+
+    private String openDt;
+
+    private String salesAmt;
+    private String salesShare;
+    private String salesInten;
+    private String salesChange;
+    private String salesAcc;
+
+    private String audiCnt;
+    private String audiInten;
+    private String audiChange;
+    private String audiAcc;
+
+    private String scrnCnt;
+    private String showCnt;
 
     public void updateFrom(WeeklyBoxOfficeEntity other) {
-        this.rnum            = other.rnum;
-        this.movieRank       = other.movieRank;
-        this.rankInten       = other.rankInten;
-        this.rankOldAndNew   = other.rankOldAndNew;
-        this.openDt          = other.openDt;
-        this.salesShare      = other.salesShare;
-        this.salesInten      = other.salesInten;
-        this.salesChange     = other.salesChange;
-        this.salesAcc        = other.salesAcc;
-        this.audiCnt         = other.audiCnt;
-        this.audiInten       = other.audiInten;
-        this.audiChange      = other.audiChange;
-        this.audiAcc         = other.audiAcc;
-        this.scrnCnt         = other.scrnCnt;
-        this.showCnt         = other.showCnt;
-        this.salesAmt       = other.salesAmt;
+        this.rnum          = other.rnum;
+        this.movieRank     = other.movieRank;
+        this.rankInten     = other.rankInten;
+        this.rankOldAndNew = other.rankOldAndNew;
+        this.openDt        = other.openDt;
+        this.salesAmt      = other.salesAmt;
+        this.salesShare    = other.salesShare;
+        this.salesInten    = other.salesInten;
+        this.salesChange   = other.salesChange;
+        this.salesAcc      = other.salesAcc;
+        this.audiCnt       = other.audiCnt;
+        this.audiInten     = other.audiInten;
+        this.audiChange    = other.audiChange;
+        this.audiAcc       = other.audiAcc;
+        this.scrnCnt       = other.scrnCnt;
+        this.showCnt       = other.showCnt;
     }
 }

--- a/src/main/java/com/insidemovie/backend/api/movie/repository/DailyBoxOfficeRepository.java
+++ b/src/main/java/com/insidemovie/backend/api/movie/repository/DailyBoxOfficeRepository.java
@@ -1,16 +1,37 @@
 package com.insidemovie.backend.api.movie.repository;
 
 import com.insidemovie.backend.api.movie.entity.boxoffice.DailyBoxOfficeEntity;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 public interface DailyBoxOfficeRepository extends JpaRepository<DailyBoxOfficeEntity, Long> {
-    void deleteByTargetDate(LocalDate date);
-    Page<DailyBoxOfficeEntity> findByTargetDate(LocalDate date, Pageable pageable);
+
     Optional<DailyBoxOfficeEntity> findByTargetDateAndMovieCd(LocalDate targetDate, String movieCd);
 
-    Optional<DailyBoxOfficeEntity> findByMovie_TmdbMovieIdAndTargetDate(Long tmdbMovieId, LocalDate date);
+    Optional<DailyBoxOfficeEntity> findByMovie_TmdbMovieIdAndTargetDate(Long tmdbMovieId, LocalDate targetDate);
+
+    @Query("select max(d.targetDate) from DailyBoxOfficeEntity d")
+    Optional<LocalDate> findLatestTargetDate();
+
+    // (1) 특정 날짜 정렬 (movie_rank 가 varchar 이므로 cast)
+    @Query(value = """
+        select * 
+        from daily_box_office
+        where target_date = :targetDate
+        order by cast(movie_rank as unsigned)
+        """, nativeQuery = true)
+    List<DailyBoxOfficeEntity> findAllSortedByTargetDate(@Param("targetDate") LocalDate targetDate);
+
+    // (2) 최신 날짜 + 정렬 한번에
+    @Query(value = """
+        select * 
+        from daily_box_office
+        where target_date = (select max(target_date) from daily_box_office)
+        order by cast(movie_rank as unsigned)
+        """, nativeQuery = true)
+    List<DailyBoxOfficeEntity> findLatestSorted();
 }

--- a/src/main/java/com/insidemovie/backend/api/movie/repository/WeeklyBoxOfficeRepository.java
+++ b/src/main/java/com/insidemovie/backend/api/movie/repository/WeeklyBoxOfficeRepository.java
@@ -1,15 +1,31 @@
 package com.insidemovie.backend.api.movie.repository;
 
 import com.insidemovie.backend.api.movie.entity.boxoffice.WeeklyBoxOfficeEntity;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import java.util.List;
 
 public interface WeeklyBoxOfficeRepository extends JpaRepository<WeeklyBoxOfficeEntity, Long> {
-    Page<WeeklyBoxOfficeEntity> findByYearWeekTime(String yearWeekTime, Pageable pageable);
-    Optional<WeeklyBoxOfficeEntity> findFirstByOrderByYearWeekTimeDesc();
+
     Optional<WeeklyBoxOfficeEntity> findByYearWeekTimeAndMovieCd(String yearWeekTime, String movieCd);
 
     Optional<WeeklyBoxOfficeEntity> findByMovie_TmdbMovieIdAndYearWeekTime(Long tmdbMovieId, String yearWeekTime);
+
+    @Query(value = """
+        select * 
+        from weekly_box_office
+        where year_week_time = :yearWeek
+        order by cast(movie_rank as unsigned)
+        """, nativeQuery = true)
+    List<WeeklyBoxOfficeEntity> findAllSortedByYearWeek(@Param("yearWeek") String yearWeek);
+
+    @Query(value = """
+        select * 
+        from weekly_box_office
+        where year_week_time = (select max(year_week_time) from weekly_box_office)
+        order by cast(movie_rank as unsigned)
+        """, nativeQuery = true)
+    List<WeeklyBoxOfficeEntity> findLatestSorted();
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -62,8 +62,8 @@ kobis:
 
 scheduler:
   cron:
-    daily: "0 09 20 * * ?"
-    weekly: "0 09 20 * * ?"
+    daily: "0 15 7 * * *"
+    weekly: "0 35 07 * * MON"
     request_movie: "0 45 14 * * *"
   zone: "Asia/Seoul"
 


### PR DESCRIPTION
## 📣 Related Issue
- close #189 

## 📝 Summary
박스오피스 에러 해결

`pull` 받고도 박스오피스 에러 나면,
수동으로 unique 제약 풀어줘야합니다.

```sql
SHOW INDEX FROM daily_box_office;
```

결과에 `UKkyniw4btiaxmmhrt2ahxqlobb (Column: tmdb_id, Non_unique=0)` 가 있으면 아직 제거 안 된 것.

아직 `tmdb_id`가 로컬 DB에서 unique 이기 때문에.
아래 쿼리 사용하여 해결됩니다.
```sql
ALTER TABLE daily_box_office
DROP INDEX UKkyniw4btiaxmmhrt2ahxqlobb;
```