### PR TITLE
[FEAT] 회원가입 시 MemberEmotionSummary 초기 데이터 자동 생성

### DIFF
--- a/src/main/java/com/insidemovie/backend/api/member/entity/MemberEmotionSummary.java
+++ b/src/main/java/com/insidemovie/backend/api/member/entity/MemberEmotionSummary.java
@@ -31,7 +31,12 @@ public class MemberEmotionSummary {
     private Float disgust;
 
     @Enumerated(EnumType.STRING)
+    @Column(nullable = true)
     private EmotionType repEmotionType; // 대표 감정
+
+    public void setMember(Member member) {
+        this.member = member;
+    }
 
     // 평균 감정 정보를 DTO로부터 갱신
     public void updateFromDTO(EmotionAvgDTO dto) {

--- a/src/main/java/com/insidemovie/backend/api/member/service/MemberService.java
+++ b/src/main/java/com/insidemovie/backend/api/member/service/MemberService.java
@@ -60,6 +60,20 @@ public class MemberService {
 
         String encodedPassword = passwordEncoder.encode(requestDto.getPassword());
         Member member = requestDto.toEntity(encodedPassword);
+
+        // MemberEmotionSummary 생성 및 연결
+        MemberEmotionSummary summary = MemberEmotionSummary.builder()
+                .joy(0f)
+                .sadness(0f)
+                .fear(0f)
+                .anger(0f)
+                .disgust(0f)
+                .repEmotionType(null)
+                .build();
+
+        summary.setMember(member);
+        member.setEmotionSummary(summary);
+
         memberRepository.save(member);
 
         Map<String, Object> result = new HashMap<>();
@@ -87,6 +101,20 @@ public class MemberService {
                 .socialType("KAKAO")
                 .authority(Authority.ROLE_USER)
                 .build();
+
+        // MemberEmotionSummary 생성 및 연결
+        MemberEmotionSummary summary = MemberEmotionSummary.builder()
+                .member(member)
+                .joy(0f)
+                .sadness(0f)
+                .fear(0f)
+                .anger(0f)
+                .disgust(0f)
+                .repEmotionType(null)
+                .build();
+
+        summary.setMember(member);
+        member.setEmotionSummary(summary);
 
         memberRepository.save(member);
 


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #200 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 회원가입 시 5개 감정 joy, sadness, fear, anger, disgust는 모두 0으로 설정
- 대표 감정 repEmotionType은 null로 설정

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
