### PR TITLE
[FEAT] 응답에 대표 감정 수치랑 사용자 프로필 반환 추가

### DIFF
--- a/src/main/java/com/insidemovie/backend/api/member/controller/MemberController.java
+++ b/src/main/java/com/insidemovie/backend/api/member/controller/MemberController.java
@@ -139,16 +139,16 @@ public class MemberController {
         return ApiResponse.success_only(SuccessStatus.UPDATE_PASSWORD_SUCCESS);
     }
 
-    @Operation(summary = "프로필 감정(이미지) 변경 API", description = "프로필 이미지를 변경합니다.")
-    @PatchMapping("/emotion")
-    public ResponseEntity<ApiResponse<Map<String, String>>> updateProfileEmotion(
-            @AuthenticationPrincipal UserDetails userDetails,
-            @RequestBody ProfileEmotionUpdateRequestDto requestDto
-    ) {
-        EmotionType updated = memberService.updateProfileEmotion(userDetails.getUsername(), requestDto.getProfileEmotion());
-        Map<String, String> data = Map.of("profileEmotion", updated.name());
-        return ApiResponse.success(SuccessStatus.UPDATE_PROFILE_IMAGE_SUCCESS, data);
-    }
+//    @Operation(summary = "프로필 감정(이미지) 변경 API", description = "프로필 이미지를 변경합니다.")
+//    @PatchMapping("/emotion")
+//    public ResponseEntity<ApiResponse<Map<String, String>>> updateProfileEmotion(
+//            @AuthenticationPrincipal UserDetails userDetails,
+//            @RequestParam("emotion") EmotionType emotion
+//    ) {
+//        EmotionType updated = memberService.updateProfileEmotion(userDetails.getUsername(), emotion);
+//        Map<String, String> data = Map.of("profileEmotion", updated.name());
+//        return ApiResponse.success(SuccessStatus.UPDATE_PROFILE_IMAGE_SUCCESS, data);
+//    }
 
     @Operation(summary = "내가 작성한 리뷰 목록 조회", description = "로그인한 사용자의 리뷰 목록을 페이징하여 조회합니다.")
     @GetMapping("/my-review")

--- a/src/main/java/com/insidemovie/backend/api/member/entity/Member.java
+++ b/src/main/java/com/insidemovie/backend/api/member/entity/Member.java
@@ -60,10 +60,6 @@ public class Member extends BaseTimeEntity {
     @Builder.Default
     private Boolean isBanned = false;  // 정지
 
-    @Enumerated(EnumType.STRING)
-    @Column(name = "profile_emotion")
-    private EmotionType profileEmotion;  // 프로필 이미지
-
     @Builder
     public Member(String email, String password, String nickname, Authority authority) {
         this.email = email;
@@ -80,11 +76,6 @@ public class Member extends BaseTimeEntity {
     // 닉네임 변경
     public void updateNickname(String nickname) {
         this.nickname = nickname;
-    }
-
-    // 프로필 이미지 변경
-    public void updateProfileEmotion(EmotionType emotionType) {
-        this.profileEmotion = emotionType;
     }
 
     // 비밀번호 변경

--- a/src/main/java/com/insidemovie/backend/api/member/service/MemberService.java
+++ b/src/main/java/com/insidemovie/backend/api/member/service/MemberService.java
@@ -254,14 +254,14 @@ public class MemberService {
         member.updatePassword(newEncoded);
     }
 
-    // 프로필 감정
-    @Transactional
-    public EmotionType updateProfileEmotion(String email, EmotionType emotionType) {
-        Member member = memberRepository.findByEmail(email)
-                .orElseThrow(() -> new NotFoundException(ErrorStatus.NOT_FOUND_MEMBERID_EXCEPTION.getMessage()));
-        member.updateProfileEmotion(emotionType);
-        return member.getProfileEmotion();
-    }
+//    // 프로필 감정
+//    @Transactional
+//    public EmotionType updateProfileEmotion(String email, EmotionType emotionType) {
+//        Member member = memberRepository.findByEmail(email)
+//                .orElseThrow(() -> new NotFoundException(ErrorStatus.NOT_FOUND_MEMBERID_EXCEPTION.getMessage()));
+//        member.updateProfileEmotion(emotionType);
+//        return member.getProfileEmotion();
+//    }
 
     // 로그아웃
     @Transactional

--- a/src/main/java/com/insidemovie/backend/api/movie/dto/MovieSearchResDto.java
+++ b/src/main/java/com/insidemovie/backend/api/movie/dto/MovieSearchResDto.java
@@ -16,6 +16,7 @@ public class MovieSearchResDto {
     private String posterPath;
     private String title;
     private Double voteAverage;
-    private EmotionType mainEmotion;
     private LocalDate releaseDate;
+    private EmotionType mainEmotion;
+    private Double mainEmotionValue;
 }

--- a/src/main/java/com/insidemovie/backend/api/movie/dto/MyMovieResponseDTO.java
+++ b/src/main/java/com/insidemovie/backend/api/movie/dto/MyMovieResponseDTO.java
@@ -16,4 +16,5 @@ public class MyMovieResponseDTO {
     private String title;
     private Double voteAverage;
     private EmotionType mainEmotion;
+    private Double mainEmotionValue;
 }

--- a/src/main/java/com/insidemovie/backend/api/movie/service/MovieLikeService.java
+++ b/src/main/java/com/insidemovie/backend/api/movie/service/MovieLikeService.java
@@ -48,6 +48,17 @@ public class MovieLikeService {
             Movie movie = movielike.getMovie();
             EmotionAvgDTO avg = movieService.getMovieEmotionSummary(movie.getId());
             EmotionType mainEmotion = avg.getRepEmotionType();
+
+            // mainEmotion에 해당하는 수치 꺼내기
+            double emainEmotionValue = switch (mainEmotion) {
+                case JOY -> avg.getJoy();
+                case SADNESS -> avg.getSadness();
+                case ANGER -> avg.getAnger();
+                case FEAR -> avg.getFear();
+                case DISGUST -> avg.getDisgust();
+                case NONE -> 0.0;
+            };
+
             return MyMovieResponseDTO.builder()
                     .movieReactionId(movielike.getId())
                     .movieId(movie.getId())
@@ -55,6 +66,7 @@ public class MovieLikeService {
                     .title(movie.getTitle())
                     .voteAverage(movie.getVoteAverage())
                     .mainEmotion(mainEmotion)
+                    .mainEmotionValue(emainEmotionValue)
                     .build();
         });
         return new PageResDto<>(dto);

--- a/src/main/java/com/insidemovie/backend/api/movie/service/MovieService.java
+++ b/src/main/java/com/insidemovie/backend/api/movie/service/MovieService.java
@@ -292,6 +292,7 @@ public class MovieService {
         Page<MovieSearchResDto> movieSearchResDtos = movies.map(this::convertEntityToDto);
         return new PageResDto<>(movieSearchResDtos);
     }
+
     /*
      * TODO: 영화 장르와, 타이틀로 검색했을때 검색되도록
      *   - "액"이 포함된 영화 타이틀을 검색하고 싶어도 액션으로 인식되어 액션 영화 나옴
@@ -323,14 +324,26 @@ public class MovieService {
         EmotionAvgDTO avg = getMovieEmotionSummary(movie.getId());
         EmotionType mainEmotion = avg.getRepEmotionType();
 
+        // 감정 수치 계산
+        double mainEmotionValue = switch (mainEmotion) {
+            case JOY -> avg.getJoy();
+            case SADNESS -> avg.getSadness();
+            case ANGER -> avg.getAnger();
+            case FEAR -> avg.getFear();
+            case DISGUST -> avg.getDisgust();
+            case NONE -> 0.0;
+        };
+
         MovieSearchResDto movieSearchResDto = new MovieSearchResDto();
         movieSearchResDto.setId(movie.getId());
         movieSearchResDto.setTitle(movie.getTitle());
         movieSearchResDto.setPosterPath(movie.getPosterPath());
         movieSearchResDto.setVoteAverage(movie.getVoteAverage());
         movieSearchResDto.setMainEmotion(mainEmotion);
+        movieSearchResDto.setMainEmotionValue(mainEmotionValue);
         return movieSearchResDto;
     }
+
     // 영화에 달린 리뷰들의 감정 평균 조회
     @Transactional
     public EmotionAvgDTO getMovieEmotionSummary(Long movieId) {
@@ -475,12 +488,23 @@ public class MovieService {
             MovieSearchResDto dto = new MovieSearchResDto();
             EmotionAvgDTO avg = getMovieEmotionSummary(movie.getId());
             EmotionType mainEmotion = avg.getRepEmotionType();
+
+            double mainEmotionValue = switch (mainEmotion) {
+                case JOY -> avg.getJoy();
+                case SADNESS -> avg.getSadness();
+                case ANGER -> avg.getAnger();
+                case FEAR -> avg.getFear();
+                case DISGUST -> avg.getDisgust();
+                case NONE -> 0.0;
+            };
+
             dto.setId(movie.getId());
             dto.setTitle(movie.getTitle());
             dto.setPosterPath(movie.getPosterPath());
             dto.setVoteAverage(movie.getVoteAverage());
             dto.setReleaseDate(movie.getReleaseDate());
             dto.setMainEmotion(mainEmotion);
+            dto.setMainEmotionValue(mainEmotionValue);
             return dto;
         }));
     }
@@ -497,12 +521,23 @@ public class MovieService {
             MovieSearchResDto resDto = new MovieSearchResDto();
             EmotionAvgDTO avg = getMovieEmotionSummary(movie.getId());
             EmotionType mainEmotion = avg.getRepEmotionType();
+
+            double mainEmotionValue = switch (mainEmotion) {
+                case JOY -> avg.getJoy();
+                case SADNESS -> avg.getSadness();
+                case ANGER -> avg.getAnger();
+                case FEAR -> avg.getFear();
+                case DISGUST -> avg.getDisgust();
+                case NONE -> 0.0;
+            };
+
             resDto.setId(movie.getId());
             resDto.setTitle(movie.getTitle());
             resDto.setPosterPath(movie.getPosterPath());
             resDto.setVoteAverage(movie.getVoteAverage());
             resDto.setReleaseDate(movie.getReleaseDate());
             resDto.setMainEmotion(mainEmotion);
+            resDto.setMainEmotionValue(mainEmotionValue);
             return resDto;
         });
 
@@ -520,13 +555,24 @@ public class MovieService {
         Page<MovieSearchResDto> dto = moviePage.map(movielike ->{
             Movie movie = movielike.getMovie();
             EmotionAvgDTO avg = getMovieEmotionSummary(movie.getId());
+
             EmotionType mainEmotion = avg.getRepEmotionType();
+            Double mainEmotionValue = switch (mainEmotion) {
+                case JOY     -> avg.getJoy();
+                case SADNESS -> avg.getSadness();
+                case ANGER   -> avg.getAnger();
+                case FEAR    -> avg.getFear();
+                case DISGUST -> avg.getDisgust();
+                default      -> 0.0;
+            };
+
             return MovieSearchResDto.builder()
                     .id(movie.getId())
                     .posterPath(movie.getPosterPath())
                     .title(movie.getTitle())
                     .voteAverage(movie.getVoteAverage())
                     .mainEmotion(mainEmotion)
+                    .mainEmotionValue(mainEmotionValue)
                     .build();
         });
         return new PageResDto<>(dto);

--- a/src/main/java/com/insidemovie/backend/api/review/dto/ReviewResponseDTO.java
+++ b/src/main/java/com/insidemovie/backend/api/review/dto/ReviewResponseDTO.java
@@ -1,5 +1,6 @@
 package com.insidemovie.backend.api.review.dto;
 
+import com.insidemovie.backend.api.constant.EmotionType;
 import com.insidemovie.backend.api.constant.ReportStatus;
 import lombok.Builder;
 import lombok.Getter;
@@ -24,6 +25,7 @@ public class ReviewResponseDTO {
     private boolean myLike;  // 내가 좋아요 누른 리뷰
 
     private String nickname;
+    private EmotionType profileEmotion;
 
     private Long memberId;  // 작성자 ID
     private Long movieId;

--- a/src/main/java/com/insidemovie/backend/api/review/dto/ReviewResponseDTO.java
+++ b/src/main/java/com/insidemovie/backend/api/review/dto/ReviewResponseDTO.java
@@ -25,7 +25,6 @@ public class ReviewResponseDTO {
     private boolean myLike;  // 내가 좋아요 누른 리뷰
 
     private String nickname;
-    private EmotionType profileEmotion;
 
     private Long memberId;  // 작성자 ID
     private Long movieId;

--- a/src/main/java/com/insidemovie/backend/api/review/service/ReviewService.java
+++ b/src/main/java/com/insidemovie/backend/api/review/service/ReviewService.java
@@ -280,7 +280,6 @@ public class ReviewService {
                 .createdAt(review.getCreatedAt())
                 .likeCount(review.getLikeCount())
                 .nickname(review.getMember().getNickname())
-                .profileEmotion(review.getMember().getProfileEmotion())
                 .memberId(review.getMember().getId())
                 .movieId(review.getMovie().getId())
                 .myReview(myReview)

--- a/src/main/java/com/insidemovie/backend/api/review/service/ReviewService.java
+++ b/src/main/java/com/insidemovie/backend/api/review/service/ReviewService.java
@@ -280,6 +280,7 @@ public class ReviewService {
                 .createdAt(review.getCreatedAt())
                 .likeCount(review.getLikeCount())
                 .nickname(review.getMember().getNickname())
+                .profileEmotion(review.getMember().getProfileEmotion())
                 .memberId(review.getMember().getId())
                 .movieId(review.getMovie().getId())
                 .myReview(myReview)


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #217 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- member/my-movie
- member/my-watch-movie
- movies/search/title
- movies/recommend/popular
- movies/recommend/latest
- 대표 감정에 해당하는 값 반환 추가
- 사용자 프로필 (profileEmotion) 제거

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 대표 감정 수치 50.184999999999995 이런식으로 길게 나옴 

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
