### PR TITLE
[FIX] 박스오피스 데이터 movieId에 `null`을 응답하는 것을 수정

### DIFF
--- a/src/main/java/com/insidemovie/backend/api/movie/dto/boxoffice/DailyBoxOfficeResponseDTO.java
+++ b/src/main/java/com/insidemovie/backend/api/movie/dto/boxoffice/DailyBoxOfficeResponseDTO.java
@@ -14,6 +14,7 @@ public class DailyBoxOfficeResponseDTO {
 
     public static DailyBoxOfficeResponseDTO fromEntity(DailyBoxOfficeEntity e) {
         return DailyBoxOfficeResponseDTO.builder()
+            .movieId(e.getMovie() != null ? e.getMovie().getId() : null)
             .base(BaseBoxOfficeItemDTO.builder()
                 .id(e.getId())
                 .rnum(e.getRnum())

--- a/src/main/java/com/insidemovie/backend/api/movie/dto/boxoffice/WeeklyBoxOfficeResponseDTO.java
+++ b/src/main/java/com/insidemovie/backend/api/movie/dto/boxoffice/WeeklyBoxOfficeResponseDTO.java
@@ -13,6 +13,7 @@ public class WeeklyBoxOfficeResponseDTO {
 
     public static WeeklyBoxOfficeResponseDTO fromEntity(WeeklyBoxOfficeEntity e) {
         return WeeklyBoxOfficeResponseDTO.builder()
+            .movieId(e.getMovie() != null ? e.getMovie().getId() : null)
             .base(BaseBoxOfficeItemDTO.builder()
                 .id(e.getId())
                 .rnum(e.getRnum())


### PR DESCRIPTION
## 📣 Related Issue
- close #225 

## 📝 Summary
- 박스오피스 데이터 movieId에 `null`을 응답하는 것을 수정