### PR TITLE
[FIX] 감정 상태 업데이트에 따른 대표 감정 상태 설정 에러 해결

### DIFF
--- a/src/main/java/com/insidemovie/backend/api/member/dto/emotion/EmotionAvgDTO.java
+++ b/src/main/java/com/insidemovie/backend/api/member/dto/emotion/EmotionAvgDTO.java
@@ -35,5 +35,4 @@ public class EmotionAvgDTO {
         this.disgust = disgust;
         this.repEmotionType = EmotionType.NONE; // 혹은 null
     }
-
 }

--- a/src/main/java/com/insidemovie/backend/api/movie/service/MovieEmotionSummaryService.java
+++ b/src/main/java/com/insidemovie/backend/api/movie/service/MovieEmotionSummaryService.java
@@ -20,8 +20,9 @@ public class MovieEmotionSummaryService {
     private final EmotionRepository emotionRepository;
     private final MovieEmotionSummaryRepository summaryRepository;
     private final MovieRepository movieRepository;
-    private final MovieLikeRepository movieLikeRepository;                    // ✔ 변경
-    private final MemberEmotionSummaryService memberEmotionSummaryService;    // ✔ 추가
+    private final MovieLikeRepository movieLikeRepository;
+    private final MemberEmotionSummaryService memberEmotionSummaryService;
+    private final MovieService movieService;
 
     @Transactional
     public void recalcMovieSummary(Long movieId) {
@@ -38,6 +39,9 @@ public class MovieEmotionSummaryService {
                 .disgust(0.0)
                 .repEmotionType(EmotionType.NONE)
                 .build());
+
+        EmotionType rep = movieService.calculateRepEmotion(avgDto);
+        avgDto.setRepEmotionType(rep);
 
         // 3) movie_emotion_summary 조회 또는 신규 생성
         MovieEmotionSummary summary = summaryRepository

--- a/src/main/java/com/insidemovie/backend/api/movie/service/MovieService.java
+++ b/src/main/java/com/insidemovie/backend/api/movie/service/MovieService.java
@@ -392,9 +392,9 @@ public class MovieService {
     }
 
     // 대표 감정 계산 메서드
-    private EmotionType calculateRepEmotion(EmotionAvgDTO dto) {
+    EmotionType calculateRepEmotion(EmotionAvgDTO dto) {
 
-        // 모든 값이 0인 경우 DISGUST 고정
+        // 모든 값이 0인 경우 NONE 고정
         if (dto.getJoy() == 0.0 &&
                 dto.getSadness() == 0.0 &&
                 dto.getAnger() == 0.0 &&


### PR DESCRIPTION
## 📣 Related Issue
- close #243 

## 📝 Summary
- `recalcMovieSummary()` 메서드 안에서 평균 감정 DTO를 꺼내올 때부터 이미 잘못된 값이 세팅되는 문제 해결