### PR TITLE
[FIX] 회원가입 시 감정 상태 중복 등록 오류 수정

### DIFF
--- a/src/main/java/com/insidemovie/backend/api/member/entity/MemberEmotionSummary.java
+++ b/src/main/java/com/insidemovie/backend/api/member/entity/MemberEmotionSummary.java
@@ -2,6 +2,7 @@ package com.insidemovie.backend.api.member.entity;
 
 import com.insidemovie.backend.api.constant.EmotionType;
 import com.insidemovie.backend.api.member.dto.emotion.EmotionAvgDTO;
+import com.insidemovie.backend.api.member.dto.emotion.MemberEmotionSummaryRequestDTO;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -46,5 +47,15 @@ public class MemberEmotionSummary {
         this.fear           = dto.getFear().floatValue();
         this.disgust        = dto.getDisgust().floatValue();
         this.repEmotionType = dto.getRepEmotionType();
+    }
+
+    // 회원가입 시 사용자가 선택한 영화 기반 감정 데이터를 저장
+    public void updateFromRequest(MemberEmotionSummaryRequestDTO dto, EmotionType rep) {
+        this.joy = dto.getJoy();
+        this.sadness = dto.getSadness();
+        this.anger = dto.getAnger();
+        this.fear = dto.getFear();
+        this.disgust = dto.getDisgust();
+        this.repEmotionType = rep;
     }
 }


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #251 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 회원가입 시 기본값으로 감정 상태가 삽입되어 발생된 오류 에러 대신 업데이트로 처리

- 감정 요약 등록 시 기존 데이터가 있을 경우 update, 없으면 insert 처리로 변경

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
